### PR TITLE
fix case where there is an empty constraints table

### DIFF
--- a/ResSimpy/Nexus/nexus_file_operations.py
+++ b/ResSimpy/Nexus/nexus_file_operations.py
@@ -873,7 +873,7 @@ def collect_all_tables_to_objects(nexus_file: NexusFile, table_object_map: dict[
         if table_start > 0 and check_token('END' + token_found, line):
             table_end = index
         # if we have a complete table to read in start reading it into objects
-        if 0 < table_start < table_end:
+        if 0 < table_start <= table_end:
             # cover for the case where we aren't currently reading in the table to an object.
             # if no object is provided by the map for the token found then skip the keyword and reset the tracking vars
             if table_object_map[token_found] is None:

--- a/tests/Nexus/nexus_simulator/test_nexus_surface.py
+++ b/tests/Nexus/nexus_simulator/test_nexus_surface.py
@@ -487,11 +487,20 @@ def test_load_wellbore(mocker, file_contents, wellboreprops1, wellboreprops2):
     well1	 QLIQSMAX 	3884.0  ACTIVATE
     well2	 QWSMAX 	0.0  DEACTIVATE QLIQSMAX 15.5
     ENDCONSTRAINTS
+    CONSTRAINTS
+    ENDCONSTRAINTS
+    WELLLIST RFTWELL
+    CONSTRAINTS 
+    well1 QLIQSMAX 0 DEACTIVATE
+    ENDCONSTRAINTS
     ''',
     ({'date': '01/01/2019', 'name': 'well1', 'max_surface_liquid_rate': 3884.0, 'active_node': True,
     'unit_system': UnitSystem.ENGLISH},
      {'date': '01/01/2019', 'name': 'well2', 'max_surface_water_rate': 0.0, 'active_node': False,
-      'max_surface_liquid_rate': 15.5, 'unit_system': UnitSystem.ENGLISH})),
+      'max_surface_liquid_rate': 15.5, 'unit_system': UnitSystem.ENGLISH},
+      {'date': '01/01/2019', 'name': 'well1', 'max_surface_liquid_rate': 0.0, 'active_node': False,
+                'unit_system': UnitSystem.ENGLISH},
+      )),
     ], ids=['basic_test', 'Change in Time', 'more Keywords', 'constraint table', 'multiple constraints on same well',
     'inline before table', 'QMULT', 'Clearing Constraints', 'activate keyword'])
 def test_load_constraints(mocker, file_contents, expected_content):


### PR DESCRIPTION
Covers for the weird case where someone has put:
CONSTRAINTS
ENDCONSTRAINTS

Previously this would have not cleared the table and inadvertently continued reading non-table content. 