### PR TITLE
Getting the date format for completions on a well from the wellspec file or model.

### DIFF
--- a/ResSimpy/Nexus/DataModels/NexusCompletion.py
+++ b/ResSimpy/Nexus/DataModels/NexusCompletion.py
@@ -9,6 +9,7 @@ import sys
 
 from ResSimpy.Enums.UnitsEnum import UnitSystem
 from ResSimpy.Nexus.NexusEnums import DateFormatEnum
+from ResSimpy.Nexus.NexusEnums.DateFormatEnum import DateFormat
 
 if sys.version_info >= (3, 11):
     from typing import Self
@@ -321,7 +322,7 @@ class NexusCompletion(Completion):
         return [v[0] for v in NexusCompletion.get_keyword_mapping().values()]
 
     @classmethod
-    def from_dict(cls, input_dictionary: dict[str, None | float | int | str]) -> Self:
+    def from_dict(cls, input_dictionary: dict[str, None | float | int | str], date_format: DateFormat) -> Self:
         """Generates a NexusCompletion from a dictionary."""
         for input_attr in input_dictionary:
             if input_attr == 'date' or input_attr == 'unit_system' or input_attr == 'date_format':
@@ -329,14 +330,16 @@ class NexusCompletion(Completion):
             elif input_attr not in cls.valid_attributes():
                 raise AttributeError(f'Unexpected keyword "{input_attr}" found within {input_dictionary}')
         date = input_dictionary.get('date', None)
-        date_format = input_dictionary.get('date_format')
-        if not isinstance(date_format, DateFormatEnum.DateFormat):
-            raise AttributeError(f'No date_format provided for the completion, instead got {date_format=}')
+        date_format_str = input_dictionary.get('date_format')
+        if date_format_str is not None and type(date_format_str) is str:
+            completion_date_format = DateFormat[date_format_str]
+        else:
+            completion_date_format = date_format
         if date is None:
             raise AttributeError(f'No date provided for the completion, instead got {date=}')
 
         date = str(date)
-        constructed_class = cls(date=date, date_format=date_format)
+        constructed_class = cls(date=date, date_format=completion_date_format)
         constructed_class.update(input_dictionary)
         return constructed_class
 

--- a/ResSimpy/Nexus/DataModels/NexusWell.py
+++ b/ResSimpy/Nexus/DataModels/NexusWell.py
@@ -6,6 +6,7 @@ from uuid import UUID
 
 from ResSimpy.Nexus.DataModels.NexusCompletion import NexusCompletion
 from ResSimpy.Enums.UnitsEnum import UnitSystem
+from ResSimpy.Nexus.NexusEnums.DateFormatEnum import DateFormat
 from ResSimpy.Utils.generic_repr import generic_repr
 from ResSimpy.Well import Well
 
@@ -156,7 +157,7 @@ class NexusWell(Well):
         raise ValueError('No completion found for id: {id}')
 
     def _add_completion_to_memory(self, date: str, completion_properties: dict[str, None | float | int | str],
-                                  completion_index: Optional[int] = None) -> NexusCompletion:
+                                  date_format: DateFormat, completion_index: Optional[int] = None) -> NexusCompletion:
         """Adds a perforation with the properties specified in completion_properties_list,
             if index is none then adds it to the end of the perforation list.
 
@@ -168,7 +169,7 @@ class NexusWell(Well):
         """
         completion_properties['date'] = date
         completion_properties['unit_system'] = self.unit_system
-        new_completion = NexusCompletion.from_dict(completion_properties)
+        new_completion = NexusCompletion.from_dict(completion_properties, date_format)
         if completion_index is None:
             completion_index = len(self.__completions)
         self.__completions.insert(completion_index, new_completion)

--- a/ResSimpy/Nexus/NexusWells.py
+++ b/ResSimpy/Nexus/NexusWells.py
@@ -101,10 +101,10 @@ class NexusWells(Wells):
                                                 default_units=self.__model.default_units, model_date_format=self.__model.date_format)
             self._wells += new_wells
             self.__date_format = date_format
-        self.__wells_loaded = True
+        self._wells_loaded = True
 
     def get_wells_overview(self) -> str:
-        if not self.__wells_loaded:
+        if not self._wells_loaded:
             self._load()
 
         overview: str = ''
@@ -115,7 +115,7 @@ class NexusWells(Wells):
 
     def get_wells_dates(self) -> set[str]:
         """Returns a set of the unique dates in the wellspec file over all wells."""
-        if not self.__wells_loaded:
+        if not self._wells_loaded:
             self._load()
 
         set_dates: set[str] = set()

--- a/ResSimpy/Nexus/NexusWells.py
+++ b/ResSimpy/Nexus/NexusWells.py
@@ -14,6 +14,7 @@ from ResSimpy.Enums.HowEnum import OperationEnum
 from ResSimpy.Nexus.DataModels.NexusCompletion import NexusCompletion
 from ResSimpy.Nexus.DataModels.NexusFile import NexusFile
 from ResSimpy.Nexus.DataModels.NexusWell import NexusWell
+from ResSimpy.Nexus.NexusEnums.DateFormatEnum import DateFormat
 from ResSimpy.Nexus.NexusKeywords.wells_keywords import WELLS_KEYWORDS
 from ResSimpy.Nexus.nexus_add_new_object_to_file import AddObjectOperations
 from ResSimpy.Wells import Wells
@@ -34,14 +35,20 @@ class NexusWells(Wells):
         model (Simulator): NexusSimulator object that has the instance of wells on.
     """
     __model: NexusSimulator
-    __wells: list[NexusWell] = field(default_factory=list)
-    __wells_loaded: bool = False
+    _wells: list[NexusWell] = field(default_factory=list)
+    __date_format: DateFormat
 
     def __init__(self, model: NexusSimulator) -> None:
         self.__model = model
-        self.__wells = []
+        # self.__wells = []
         self.__add_object_operations = AddObjectOperations(NexusCompletion, self.table_header, self.table_footer, model)
         super().__init__()
+
+    @property
+    def date_format(self) -> DateFormat:
+        if not self._wells_loaded:
+            self._load()
+        return self.__date_format
 
     @property
     def table_header(self) -> str:
@@ -52,26 +59,26 @@ class NexusWells(Wells):
         return ''
 
     def get_all(self) -> Sequence[NexusWell]:
-        if not self.__wells_loaded:
-            self.load()
-        return self.__wells
+        if not self._wells_loaded:
+            self._load()
+        return self._wells
 
     def get(self, well_name: str) -> Optional[NexusWell]:
         """Returns a specific well requested, or None if that well cannot be found."""
-        if not self.__wells_loaded:
-            self.load()
+        if not self._wells_loaded:
+            self._load()
 
-        wells_to_return = filter(lambda x: x.well_name.upper() == well_name.upper(), self.__wells)
+        wells_to_return = filter(lambda x: x.well_name.upper() == well_name.upper(), self._wells)
 
         return next(wells_to_return, None)
 
     def get_df(self) -> pd.DataFrame:
         # loop through wells and completions to output a table
-        if not self.__wells_loaded:
-            self.load()
+        if not self._wells_loaded:
+            self._load()
 
         store_dictionaries = []
-        for well in self.__wells:
+        for well in self._wells:
             for completion in well.completions:
                 completion_props: dict[str, None | float | int | str] = {
                     'well_name': well.well_name,
@@ -83,24 +90,25 @@ class NexusWells(Wells):
         df_store = df_store.dropna(axis=1, how='all')
         return df_store
 
-    def load(self) -> None:
+    def _load(self) -> None:
         if self.__model.model_files.well_files is None:
             raise FileNotFoundError('No wells files found for current model.')
         for method_number, well_file in self.__model.model_files.well_files.items():
             if well_file.location is None:
                 warnings.warn(f'Well file location has not been found for {well_file}')
                 continue
-            new_wells = load_wells(nexus_file=well_file, start_date=self.__model.start_date,
-                                   default_units=self.__model.default_units, date_format=self.__model.date_format)
-            self.__wells += new_wells
+            new_wells, date_format = load_wells(nexus_file=well_file, start_date=self.__model.start_date,
+                                                default_units=self.__model.default_units, model_date_format=self.__model.date_format)
+            self._wells += new_wells
+            self.__date_format = date_format
         self.__wells_loaded = True
 
     def get_wells_overview(self) -> str:
         if not self.__wells_loaded:
-            self.load()
+            self._load()
 
         overview: str = ''
-        for well in self.__wells:
+        for well in self._wells:
             overview += well.printable_well_info
 
         return overview
@@ -108,10 +116,10 @@ class NexusWells(Wells):
     def get_wells_dates(self) -> set[str]:
         """Returns a set of the unique dates in the wellspec file over all wells."""
         if not self.__wells_loaded:
-            self.load()
+            self._load()
 
         set_dates: set[str] = set()
-        for well in self.__wells:
+        for well in self._wells:
             set_dates.update(set(well.dates_of_completions))
 
         return set_dates
@@ -177,7 +185,9 @@ class NexusWells(Wells):
         well_id = well.completions[0].id
 
         # add completion in memory
-        new_completion = well._add_completion_to_memory(completion_date, completion_properties)
+        new_completion = well._add_completion_to_memory(date=completion_date,
+                                                        completion_properties=completion_properties,
+                                                        date_format=self.date_format)
 
         if self.__model.model_files.well_files is None:
             raise FileNotFoundError('No well file found, cannot modify ')

--- a/ResSimpy/Nexus/load_wells.py
+++ b/ResSimpy/Nexus/load_wells.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import warnings
-from typing import Optional
+from typing import Optional, Tuple
 from ResSimpy.Nexus.NexusEnums.DateFormatEnum import DateFormat
 import ResSimpy.Nexus.nexus_file_operations as nfo
 from ResSimpy.Nexus.DataModels.NexusFile import NexusFile
@@ -13,14 +13,14 @@ from ResSimpy.Nexus.NexusKeywords.wells_keywords import WELLS_KEYWORDS
 
 
 def load_wells(nexus_file: NexusFile, start_date: str, default_units: UnitSystem,
-               date_format: DateFormat) -> list[NexusWell]:
+               model_date_format: DateFormat) -> Tuple[list[NexusWell], DateFormat]:
     """Loads a list of Nexus Well instances and populates it with the wells completions over time from a wells file.
 
     Args:
         nexus_file (NexusFile): NexusFile containing the wellspec files.
         start_date (str): starting date of the wellspec file as a string.
         default_units (UnitSystem): default units to use if no units are found.
-        date_format (DateFormat): Date format specified in the FCS file.
+        model_date_format (DateFormat): Date format specified in the FCS file.
 
     Raises:
         ValueError: If no value is found after a TIME card.
@@ -30,7 +30,7 @@ def load_wells(nexus_file: NexusFile, start_date: str, default_units: UnitSystem
     Returns:
         list[NexusWell]: list of Nexus well classes contained within a wellspec file.
     """
-
+    date_format = model_date_format
     file_as_list = nexus_file.get_flat_list_str_file
     well_name: Optional[str] = None
     wellspec_file_units: Optional[UnitSystem] = None
@@ -136,6 +136,20 @@ def load_wells(nexus_file: NexusFile, start_date: str, default_units: UnitSystem
                 if unit.value in uppercase_line and (line.find('!') > line.find(unit.value) or line.find('!') == -1):
                     wellspec_file_units = unit
 
+        if nfo.check_token('DATEFORMAT', line):
+            new_date_format_str = nfo.get_token_value(token='DATEFORMAT', token_line=line, file_list=file_as_list)
+
+            if new_date_format_str is None:
+                raise ValueError(f"Cannot find the date format associated with the DATEFORMAT card in {line=} at line"
+                                 f" number {index}")
+
+            if new_date_format_str != date_format.value:
+                warnings.warn(f"Date format of {new_date_format_str} inconsistent with base model format of "
+                              f"{date_format.value}")
+
+            converted_format_str = new_date_format_str.replace('/', '_')
+            date_format = DateFormat[converted_format_str]
+
         if nfo.check_token('TIME', line):
             current_date = nfo.get_token_value(token='TIME', token_line=line, file_list=file_as_list)
             if current_date is None:
@@ -179,7 +193,7 @@ def load_wells(nexus_file: NexusFile, start_date: str, default_units: UnitSystem
                 well_name_list.append(well_name)
                 wells.append(new_well)
             wellspec_found = False
-    return wells
+    return wells, date_format
 
 
 def __load_wellspec_table_completions(nexus_file: NexusFile, header_index: int,

--- a/ResSimpy/Wells.py
+++ b/ResSimpy/Wells.py
@@ -12,15 +12,21 @@ from typing import Sequence, Optional
 
 @dataclass(kw_only=True)
 class Wells(ABC):
-    __wells: list[Well] = field(default_factory=list)
+    _wells: list[Well] = field(default_factory=list)
+    _wells_loaded: bool = False
 
     @property
     def wells(self):
-        return self.__wells
+        if not self._wells_loaded:
+            self._load()
+        return self._wells
 
     @wells.setter
     def wells(self, value):
-        self.__wells = value
+        self._wells = value
+
+    def _load(self) -> None:
+        raise NotImplementedError("Implement this in the derived class")
 
     def get_all(self) -> Sequence[Well]:
         raise NotImplementedError("Implement this in the derived class")

--- a/tests/Nexus/Properties/test_nexus_file_class.py
+++ b/tests/Nexus/Properties/test_nexus_file_class.py
@@ -430,7 +430,7 @@ def test_file_object_locations(mocker, fixture_for_osstat_pathlib, test_file_con
     wells_file = NexusFile.generate_file_include_structure(file_path='wells.dat', skip_arrays=True, )
 
     # Act
-    load_wells(wells_file, start_date='01/01/2012', default_units=UnitSystem.ENGLISH, date_format=DateFormat.DD_MM_YYYY)
+    load_wells(wells_file, start_date='01/01/2012', default_units=UnitSystem.ENGLISH, model_date_format=DateFormat.DD_MM_YYYY)
     result = wells_file.object_locations
 
     # Assert
@@ -752,7 +752,7 @@ def test_update_object_locations(mocker, fixture_for_osstat_pathlib, test_file_c
 
     wells_file = NexusFile.generate_file_include_structure(file_path='wells.dat', skip_arrays=True, )
     # load the uuids
-    load_wells(wells_file, start_date='01/01/2012', default_units=UnitSystem.ENGLISH, date_format=DateFormat.DD_MM_YYYY)
+    load_wells(wells_file, start_date='01/01/2012', default_units=UnitSystem.ENGLISH, model_date_format=DateFormat.DD_MM_YYYY)
 
     # Act
     # effectively add 2 lines at location 5

--- a/tests/Nexus/nexus_simulator/test_nexus_simulator.py
+++ b/tests/Nexus/nexus_simulator/test_nexus_simulator.py
@@ -1049,7 +1049,7 @@ def test_get_all(mocker: MockerFixture, fixture_for_osstat_pathlib, fcs_file_con
                               unit_system=UnitSystem.ENGLISH)]
 
     # mock out the load_wells function as that is tested elsewhere
-    mock_load_wells = mocker.Mock(return_value=loaded_wells)
+    mock_load_wells = mocker.Mock(return_value=(loaded_wells, ''))
     mocker.patch('ResSimpy.Nexus.NexusWells.load_wells', mock_load_wells)
 
     # NB file_content_as_list needs to be set as below due to the mocker open re-reading fcs contents
@@ -1066,7 +1066,7 @@ def test_get_all(mocker: MockerFixture, fixture_for_osstat_pathlib, fcs_file_con
     assert result == loaded_wells
     mock_load_wells.assert_called_once_with(nexus_file=expected_well_file,
                                             default_units=UnitSystem.ENGLISH,
-                                            start_date='', date_format=DateFormat.MM_DD_YYYY)
+                                            start_date='', model_date_format=DateFormat.MM_DD_YYYY)
 
 @pytest.mark.parametrize("fcs_file_contents", [
     ("""
@@ -1087,7 +1087,7 @@ def test_get_wells_windows(mocker: MockerFixture, fixture_for_osstat_pathlib, fc
                               unit_system=UnitSystem.ENGLISH)]
 
     # mock out the load_wells function as that is tested elsewhere
-    mock_load_wells = mocker.Mock(return_value=loaded_wells)
+    mock_load_wells = mocker.Mock(return_value=(loaded_wells, ''))
     mocker.patch('ResSimpy.Nexus.NexusWells.load_wells', mock_load_wells)
 
     # NB file_content_as_list needs to be set as below due to the mocker open re-reading fcs contents
@@ -1104,7 +1104,7 @@ def test_get_wells_windows(mocker: MockerFixture, fixture_for_osstat_pathlib, fc
     assert result == loaded_wells
     mock_load_wells.assert_called_once_with(nexus_file=expected_well_file,
                                             default_units=UnitSystem.ENGLISH,
-                                            start_date='', date_format = DateFormat.MM_DD_YYYY)
+                                            start_date='', model_date_format = DateFormat.MM_DD_YYYY)
 
 
 def test_get_df(mocker: MockerFixture, fixture_for_osstat_pathlib):
@@ -1130,7 +1130,7 @@ def test_get_df(mocker: MockerFixture, fixture_for_osstat_pathlib):
     loaded_wells_df = loaded_wells_df.astype(
         {'well_radius': 'float64', 'i': 'int64', 'j': 'int64', 'k': 'int64'})
 
-    mock_load_wells = mocker.Mock(return_value=loaded_wells)
+    mock_load_wells = mocker.Mock(return_value=(loaded_wells, ''))
     mocker.patch('ResSimpy.Nexus.NexusWells.load_wells', mock_load_wells)
     simulation = NexusSimulator(origin='nexus_run.fcs')
     # Act
@@ -1162,7 +1162,7 @@ def test_get(mocker: MockerFixture, fcs_file_contents: str, fixture_for_osstat_p
                     ]
 
     # mock out the load_wells function as that is tested elsewhere
-    mock_load_wells = mocker.Mock(return_value=loaded_wells)
+    mock_load_wells = mocker.Mock(return_value=(loaded_wells, ''))
     mocker.patch('ResSimpy.Nexus.NexusWells.load_wells', mock_load_wells)
 
     # NB file_content_as_list needs to be set as below due to the mocker open re-reading fcs contents
@@ -1179,7 +1179,7 @@ def test_get(mocker: MockerFixture, fcs_file_contents: str, fixture_for_osstat_p
     assert result == loaded_wells[1]
     mock_load_wells.assert_called_once_with(nexus_file=expected_well_file,
                                             default_units=UnitSystem.ENGLISH,
-                                            start_date='', date_format = DateFormat.MM_DD_YYYY)
+                                            start_date='', model_date_format = DateFormat.MM_DD_YYYY)
 @pytest.mark.parametrize("fcs_file_contents", [
     ("""
        WelLS set 1 my\\wellspec\\file.dat
@@ -1202,7 +1202,7 @@ def test_get_well_windows(mocker: MockerFixture, fcs_file_contents: str, fixture
                     ]
 
     # mock out the load_wells function as that is tested elsewhere
-    mock_load_wells = mocker.Mock(return_value=loaded_wells)
+    mock_load_wells = mocker.Mock(return_value=(loaded_wells, ''))
     mocker.patch('ResSimpy.Nexus.NexusWells.load_wells', mock_load_wells)
 
     # NB file_content_as_list needs to be set as below due to the mocker open re-reading fcs contents
@@ -1219,7 +1219,7 @@ def test_get_well_windows(mocker: MockerFixture, fcs_file_contents: str, fixture
     assert result == loaded_wells[1]
     mock_load_wells.assert_called_once_with(nexus_file=expected_well_file,
                                             default_units=UnitSystem.ENGLISH,
-                                            start_date='', date_format = DateFormat.MM_DD_YYYY)
+                                            start_date='', model_date_format = DateFormat.MM_DD_YYYY)
 
 
 @pytest.mark.parametrize("fcs_file_contents", [

--- a/tests/Nexus/nexus_simulator/test_nexus_simulator.py
+++ b/tests/Nexus/nexus_simulator/test_nexus_simulator.py
@@ -33,7 +33,7 @@ from tests.multifile_mocker import mock_multiple_files
 
 def mock_multiple_opens(mocker, filename, fcs_file_contents, run_control_contents, include_contents,
                         run_control_mock=None, include_file_mock=None, log_file_mock=None, structured_grid_mock=None,
-                        surface_1_mock=None, surface_2_mock=None):
+                        surface_1_mock=None, surface_2_mock=None, wellspec_mock=None):
     """Mock method that returns different test file contents depending upon the file name"""
     if "fcs" in filename:
         file_contents = fcs_file_contents
@@ -51,6 +51,8 @@ def mock_multiple_opens(mocker, filename, fcs_file_contents, run_control_content
         return log_file_mock
     elif "structured_grid" in filename:
         return structured_grid_mock
+    elif "wellspec" in filename:
+        return wellspec_mock
     else:
         raise FileNotFoundError(filename)
     open_mock = mocker.mock_open(read_data=file_contents)

--- a/tests/Nexus/test_load_wells.py
+++ b/tests/Nexus/test_load_wells.py
@@ -76,7 +76,7 @@ def test_load_basic_wellspec(mocker, fixture_for_osstat_pathlib, file_contents, 
     wells_file = NexusFile.generate_file_include_structure('test/file/location.dat')
     # Act
     result_wells = load_wells(wells_file, start_date=start_date, default_units=UnitSystem.ENGLISH,
-                              model_date_format=date_format)
+                              model_date_format=date_format)[0]
 
     # Assert
     # Deep compare expected and received wells
@@ -168,7 +168,7 @@ WELLMOD	RU001	DKH	CON	0
 
     # Act
     result_wells = load_wells(wells_file, start_date=start_date, default_units=UnitSystem.ENGLISH,
-                              model_date_format=date_format)
+                              model_date_format=date_format)[0]
 
     # Assert
     assert result_wells == expected_wells
@@ -251,7 +251,7 @@ def test_load_wells_multiple_wells_multiple_dates(mocker, fixture_for_osstat_pat
 
     # Act
     result_wells = load_wells(wells_file, start_date=start_date, default_units=UnitSystem.ENGLISH,
-                              model_date_format=date_format)
+                              model_date_format=date_format)[0]
 
     # Assert
     assert result_wells == expected_wells
@@ -292,7 +292,7 @@ def test_load_wells_all_columns_present_structured_grid(mocker, fixture_for_osst
 
     # Act
     result_wells = load_wells(wells_file, start_date=start_date, default_units=UnitSystem.ENGLISH,
-                              model_date_format=date_format)
+                              model_date_format=date_format)[0]
 
     # Assert
     assert result_wells == expected_wells
@@ -361,7 +361,7 @@ def test_load_wells_all_columns_unstructured_grid(mocker, fixture_for_osstat_pat
 
     # Act
     result_wells = load_wells(wells_file, start_date=start_date, default_units=UnitSystem.ENGLISH,
-                              model_date_format=date_format)
+                              model_date_format=date_format)[0]
 
     # Assert
     assert result_wells == expected_wells
@@ -413,7 +413,7 @@ def test_load_wells_rel_perm_tables(mocker, fixture_for_osstat_pathlib):
 
     # Act
     result_wells = load_wells(wells_file, start_date=start_date, default_units=UnitSystem.ENGLISH,
-                              model_date_format=date_format)
+                              model_date_format=date_format)[0]
 
     # Assert
     assert result_wells == expected_wells
@@ -457,7 +457,7 @@ def test_load_wells_na_values_converted_to_none(mocker, fixture_for_osstat_pathl
 
     # Act
     result_wells = load_wells(wells_file, start_date=start_date, default_units=UnitSystem.ENGLISH,
-                              model_date_format=date_format)
+                              model_date_format=date_format)[0]
 
     # Assert
     assert result_wells == expected_wells
@@ -536,7 +536,7 @@ def test_correct_units_loaded(mocker, fixture_for_osstat_pathlib, file_contents,
 
     # Act
     result_wells = load_wells(wells_file, start_date=start_date, default_units=UnitSystem.ENGLISH,
-                              model_date_format=date_format)
+                              model_date_format=date_format)[0]
 
     # Assert
     assert result_wells == expected_wells

--- a/tests/Nexus/test_load_wells.py
+++ b/tests/Nexus/test_load_wells.py
@@ -1,4 +1,5 @@
 import pytest
+from pytest_mock import MockerFixture
 
 from ResSimpy.Nexus.DataModels.NexusCompletion import NexusCompletion
 from ResSimpy.Nexus.DataModels.NexusFile import NexusFile
@@ -7,6 +8,9 @@ from ResSimpy.Nexus.DataModels.NexusWell import NexusWell
 from ResSimpy.Enums.UnitsEnum import UnitSystem
 from ResSimpy.Nexus.NexusEnums.DateFormatEnum import DateFormat
 from ResSimpy.Nexus.load_wells import load_wells
+from tests.Nexus.nexus_simulator.test_nexus_simulator import mock_multiple_opens
+from tests.multifile_mocker import mock_multiple_files
+from tests.utility_for_tests import get_fake_nexus_simulator
 
 
 @pytest.mark.parametrize("file_contents, expected_name",
@@ -45,14 +49,15 @@ C    2  2  2  2 (commented line using 'C')
     2  1  3  4.5
     7 6 8   9.11
     """, "well3"),
-    ("""
+                          ("""
     WELLSPEC well3
     ! RADW radw
     JW iw l radw
     2  1  3  4.5
     7 6 8   9.11
     WELLMOD PD---_BB KHMULT CON 0.4""", "well3"),
-    ], ids=["basic case", "swapped columns", "number name", "comments", "different cases", "WELLMOD"])
+                          ],
+                         ids=["basic case", "swapped columns", "number name", "comments", "different cases", "WELLMOD"])
 def test_load_basic_wellspec(mocker, fixture_for_osstat_pathlib, file_contents, expected_name):
     # Arrange
     start_date = '01/01/2023'
@@ -70,7 +75,8 @@ def test_load_basic_wellspec(mocker, fixture_for_osstat_pathlib, file_contents, 
     mocker.patch("builtins.open", open_mock)
     wells_file = NexusFile.generate_file_include_structure('test/file/location.dat')
     # Act
-    result_wells = load_wells(wells_file, start_date=start_date, default_units=UnitSystem.ENGLISH, date_format=date_format)
+    result_wells = load_wells(wells_file, start_date=start_date, default_units=UnitSystem.ENGLISH,
+                              model_date_format=date_format)
 
     # Assert
     # Deep compare expected and received wells
@@ -130,15 +136,17 @@ WELLMOD	RU001	DKH	CON	0
                                                    date_format=date_format, unit_system=UnitSystem.ENGLISH)
 
     expected_well_3_completion_1 = NexusCompletion(date=start_date, i=126, j=504, k=3, skin=0, well_radius=0.354,
-                                                   partial_perf=1, date_format=date_format, unit_system=UnitSystem.ENGLISH)
+                                                   partial_perf=1, date_format=date_format,
+                                                   unit_system=UnitSystem.ENGLISH)
     expected_well_3_completion_2 = NexusCompletion(date=start_date, i=126, j=504, k=4, skin=0, well_radius=0.354,
-                                                   partial_perf=1, date_format=date_format, unit_system=UnitSystem.ENGLISH)
+                                                   partial_perf=1, date_format=date_format,
+                                                   unit_system=UnitSystem.ENGLISH)
 
     expected_well_4_completion_1 = NexusCompletion(date=start_date, i=1, j=2, k=3, well_radius=4.5,
                                                    date_format=date_format, unit_system=UnitSystem.ENGLISH)
     expected_well_4_completion_2 = NexusCompletion(date=start_date, i=6, j=7, k=8, well_radius=9.11,
                                                    date_format=date_format, unit_system=UnitSystem.ENGLISH)
-    
+
     expected_well_1 = NexusWell(well_name='DEV1',
                                 completions=[expected_well_1_completion_1, expected_well_1_completion_2],
                                 unit_system=UnitSystem.ENGLISH)
@@ -159,7 +167,8 @@ WELLMOD	RU001	DKH	CON	0
     wells_file = NexusFile.generate_file_include_structure('test/file/location.dat')
 
     # Act
-    result_wells = load_wells(wells_file, start_date=start_date, default_units=UnitSystem.ENGLISH, date_format=date_format) 
+    result_wells = load_wells(wells_file, start_date=start_date, default_units=UnitSystem.ENGLISH,
+                              model_date_format=date_format)
 
     # Assert
     assert result_wells == expected_wells
@@ -210,7 +219,8 @@ def test_load_wells_multiple_wells_multiple_dates(mocker, fixture_for_osstat_pat
     expected_well_1_completion_4 = NexusCompletion(date='15/10/2023', i=5, j=9, k=56, well_radius=37.23,
                                                    date_format=date_format, unit_system=UnitSystem.ENGLISH)
     expected_well_1_completion_5 = NexusCompletion(date='15/12/2023', i=1, j=2, k=4, perm_thickness_ovr=1.423,
-                                                   bore_radius=1.55, date_format=date_format, unit_system=UnitSystem.ENGLISH)
+                                                   bore_radius=1.55, date_format=date_format,
+                                                   unit_system=UnitSystem.ENGLISH)
 
     expected_well_2_completion_1 = NexusCompletion(date='01/08/2023', i=12, j=12, k=13, well_radius=4.50000000000,
                                                    date_format=date_format, unit_system=UnitSystem.ENGLISH)
@@ -240,7 +250,8 @@ def test_load_wells_multiple_wells_multiple_dates(mocker, fixture_for_osstat_pat
     wells_file = NexusFile.generate_file_include_structure('test/file/location.dat')
 
     # Act
-    result_wells = load_wells(wells_file, start_date=start_date, default_units=UnitSystem.ENGLISH, date_format=date_format)
+    result_wells = load_wells(wells_file, start_date=start_date, default_units=UnitSystem.ENGLISH,
+                              model_date_format=date_format)
 
     # Assert
     assert result_wells == expected_wells
@@ -280,7 +291,8 @@ def test_load_wells_all_columns_present_structured_grid(mocker, fixture_for_osst
     wells_file = NexusFile.generate_file_include_structure('test/file/location.dat')
 
     # Act
-    result_wells = load_wells(wells_file, start_date=start_date, default_units=UnitSystem.ENGLISH, date_format=date_format)
+    result_wells = load_wells(wells_file, start_date=start_date, default_units=UnitSystem.ENGLISH,
+                              model_date_format=date_format)
 
     # Assert
     assert result_wells == expected_wells
@@ -313,7 +325,6 @@ def test_load_wells_all_columns_present_structured_grid(mocker, fixture_for_osst
     assert result_wells[0].completions[0].kh_mult == expected_wells[0].completions[0].kh_mult
     assert result_wells[0].completions[0].depth_to_top_str == expected_wells[0].completions[0].depth_to_top_str
     assert result_wells[0].completions[0].depth_to_bottom_str == expected_wells[0].completions[0].depth_to_bottom_str
-
 
 
 def test_load_wells_all_columns_unstructured_grid(mocker, fixture_for_osstat_pathlib):
@@ -349,7 +360,8 @@ def test_load_wells_all_columns_unstructured_grid(mocker, fixture_for_osstat_pat
     wells_file = NexusFile.generate_file_include_structure('test/file/location.dat')
 
     # Act
-    result_wells = load_wells(wells_file, start_date=start_date, default_units=UnitSystem.ENGLISH, date_format=date_format)
+    result_wells = load_wells(wells_file, start_date=start_date, default_units=UnitSystem.ENGLISH,
+                              model_date_format=date_format)
 
     # Assert
     assert result_wells == expected_wells
@@ -368,12 +380,16 @@ def test_load_wells_rel_perm_tables(mocker, fixture_for_osstat_pathlib):
 
     """
     expected_rel_perm_end_point_1 = NexusRelPermEndPoint(swl=0.1, swr=0.2, swu=0.54, sgl=0.5, sgr=0.4, sgu=0.2,
-                                                         swro=0.01, sgro=1, sgrw=1, krw_swro=0.5, krw_swu=0.2, krg_sgro=1, krg_sgu=0.2,
-                                                         kro_swl=0.4, kro_swr=1, kro_sgl=1, kro_sgr=0.2, krw_sgl=0.3, krw_sgr=0.1,
+                                                         swro=0.01, sgro=1, sgrw=1, krw_swro=0.5, krw_swu=0.2,
+                                                         krg_sgro=1, krg_sgu=0.2,
+                                                         kro_swl=0.4, kro_swr=1, kro_sgl=1, kro_sgr=0.2, krw_sgl=0.3,
+                                                         krw_sgr=0.1,
                                                          krg_sgrw=0.125, sgtr=0.134, sotr=0.7, )
     expected_rel_perm_end_point_2 = NexusRelPermEndPoint(swl=0.05, swr=0.15, swu=0.49, sgl=0.45, sgr=0.35, sgu=0.15,
-                                                         swro=0, sgro=0.95, sgrw=0.95, krw_swro=0.45, krw_swu=0.15, krg_sgro=0.95, krg_sgu=0.15,
-                                                         kro_swl=0.35, kro_swr=0.95, kro_sgl=0.95, kro_sgr=0.15, krw_sgl=0.25, krw_sgr=0.05,
+                                                         swro=0, sgro=0.95, sgrw=0.95, krw_swro=0.45, krw_swu=0.15,
+                                                         krg_sgro=0.95, krg_sgu=0.15,
+                                                         kro_swl=0.35, kro_swr=0.95, kro_sgl=0.95, kro_sgr=0.15,
+                                                         krw_sgl=0.25, krw_sgr=0.05,
                                                          krg_sgrw=0.075, sgtr=0.084, sotr=0.65, )
 
     expected_well_completion_1 = NexusCompletion(date=start_date, cell_number=1,
@@ -396,7 +412,8 @@ def test_load_wells_rel_perm_tables(mocker, fixture_for_osstat_pathlib):
     wells_file = NexusFile.generate_file_include_structure('test/file/location.dat')
 
     # Act
-    result_wells = load_wells(wells_file, start_date=start_date, default_units=UnitSystem.ENGLISH, date_format=date_format)
+    result_wells = load_wells(wells_file, start_date=start_date, default_units=UnitSystem.ENGLISH,
+                              model_date_format=date_format)
 
     # Assert
     assert result_wells == expected_wells
@@ -430,7 +447,8 @@ def test_load_wells_na_values_converted_to_none(mocker, fixture_for_osstat_pathl
                                                  unit_system=UnitSystem.ENGLISH)
 
     expected_well = NexusWell(well_name='WELL_3', completions=[expected_well_completion_1, expected_well_completion_2,
-                                                               expected_well_completion_3], unit_system=UnitSystem.ENGLISH)
+                                                               expected_well_completion_3],
+                              unit_system=UnitSystem.ENGLISH)
     expected_wells = [expected_well]
 
     open_mock = mocker.mock_open(read_data=file_contents)
@@ -438,7 +456,8 @@ def test_load_wells_na_values_converted_to_none(mocker, fixture_for_osstat_pathl
     wells_file = NexusFile.generate_file_include_structure('test/file/location.dat')
 
     # Act
-    result_wells = load_wells(wells_file, start_date=start_date, default_units=UnitSystem.ENGLISH, date_format=date_format)
+    result_wells = load_wells(wells_file, start_date=start_date, default_units=UnitSystem.ENGLISH,
+                              model_date_format=date_format)
 
     # Assert
     assert result_wells == expected_wells
@@ -516,7 +535,45 @@ def test_correct_units_loaded(mocker, fixture_for_osstat_pathlib, file_contents,
     wells_file = NexusFile.generate_file_include_structure('test/file/location.dat')
 
     # Act
-    result_wells = load_wells(wells_file, start_date=start_date, default_units=UnitSystem.ENGLISH, date_format=date_format)
+    result_wells = load_wells(wells_file, start_date=start_date, default_units=UnitSystem.ENGLISH,
+                              model_date_format=date_format)
 
     # Assert
     assert result_wells == expected_wells
+
+@pytest.mark.parametrize("first_line_wellspec, first_line_fcs_file, expected_format",
+
+[("DATEFORMAT DD/MM/YYYY", "DATEFORMAT MM/DD/YYYY", DateFormat.DD_MM_YYYY),
+("DATEFORMAT MM/DD/YYYY", "DATEFORMAT DD/MM/YYYY", DateFormat.MM_DD_YYYY),
+("", "DATEFORMAT DD/MM/YYYY", DateFormat.DD_MM_YYYY),
+("", "", DateFormat.MM_DD_YYYY)],
+
+ids=['Date format in wellspec file', 'American Date format in wellspec file',
+  'Date format in FCS file only', 'No date format specified'])
+def test_load_full_model_with_wells(mocker: MockerFixture, fixture_for_osstat_pathlib, first_line_wellspec,
+                                    first_line_fcs_file, expected_format):
+    # Arrange
+    wellspec_contents = f"""
+    {first_line_wellspec}
+    TIME 01/08/2023 !232 days
+    WELLSPEC WELL1
+    IW JW L RADW
+    1  2  3  4.5"""
+
+    fcs_file_contents = f"{first_line_fcs_file} \n WELLS Set 1 data/wells.dat\n"
+
+    def mock_open_wrapper(filename, mode):
+        mock_open = mock_multiple_files(mocker, filename, potential_file_dict={
+            'model.fcs': fcs_file_contents,
+            'data/wells.dat': wellspec_contents
+        }).return_value
+        return mock_open
+
+    mocker.patch("builtins.open", mock_open_wrapper)
+
+    # Act
+    model = get_fake_nexus_simulator(mocker=mocker, fcs_file_path='model.fcs', mock_open=False)
+
+    # Assert
+    assert model.wells.date_format == expected_format
+    assert model.wells.wells[0].completions[0].date_format == expected_format

--- a/tests/Nexus/test_nexus_well.py
+++ b/tests/Nexus/test_nexus_well.py
@@ -829,7 +829,7 @@ def test_add_completion_write(mocker, fixture_for_osstat_pathlib, file_as_list, 
     fake_nexus_sim.start_date = start_date
     # mock out open
     wells_obj = NexusWells(fake_nexus_sim)
-    wells_obj.load()
+    wells_obj.__load()
 
     add_perf_dict = {'date': add_perf_date, 'i': 4, 'j': 5, 'k': 6, 'bore_radius': 7.5, 'date_format': fake_nexus_sim.date_format}
 
@@ -871,7 +871,7 @@ def test_add_completion_correct_wellspec(mocker, fixture_for_osstat_pathlib):
     mock_nexus_sim.start_date = start_date
     # mock out open
     wells_obj = NexusWells(mock_nexus_sim)
-    wells_obj.load()
+    wells_obj._load()
 
     add_perf_dict = {'date': add_perf_date, 'i': 4, 'j': 5, 'k': 6, 'bore_radius': 7.5, 'date_format': DateFormat.DD_MM_YYYY}
 

--- a/tests/Nexus/test_nexus_well.py
+++ b/tests/Nexus/test_nexus_well.py
@@ -530,7 +530,8 @@ def test_add_completion():
     well = NexusWell(well_name='test well', completions=existing_completions,
                      unit_system=UnitSystem.METKGCM2)
     # Act
-    well._add_completion_to_memory(date=new_date, completion_properties=new_completion_props)
+    well._add_completion_to_memory(date=new_date, completion_properties=new_completion_props,
+                                   date_format=DateFormat.DD_MM_YYYY)
     # Assert
     assert well == expected_well
 
@@ -623,7 +624,7 @@ def test_well_dates(mocker):
     mocker.patch('ResSimpy.Nexus.NexusSimulator.NexusSimulator', mock_sim)
     well = NexusWells(mock_sim)
 
-    well.__setattr__('_NexusWells__wells', [NexusWell(well_name='well1', completions=well_1_completions, unit_system=UnitSystem.METRIC),
+    well.__setattr__('_wells', [NexusWell(well_name='well1', completions=well_1_completions, unit_system=UnitSystem.METRIC),
                                             NexusWell(well_name='well2', completions=well_2_completions, unit_system=UnitSystem.METRIC)])
 
     expected_result = {'01/01/2023', '01/02/2023', '01/03/2023'}
@@ -829,7 +830,7 @@ def test_add_completion_write(mocker, fixture_for_osstat_pathlib, file_as_list, 
     fake_nexus_sim.start_date = start_date
     # mock out open
     wells_obj = NexusWells(fake_nexus_sim)
-    wells_obj.__load()
+    wells_obj._load()
 
     add_perf_dict = {'date': add_perf_date, 'i': 4, 'j': 5, 'k': 6, 'bore_radius': 7.5, 'date_format': fake_nexus_sim.date_format}
 

--- a/tests/Nexus/test_nexus_write_file.py
+++ b/tests/Nexus/test_nexus_write_file.py
@@ -178,7 +178,7 @@ def test_remove_completion_write_to_file(mocker, fixture_for_osstat_pathlib, fcs
     mocker.patch('os.path.isfile', fcs_file_exists)
 
     mock_nexus_sim = NexusSimulator('fcs_file.fcs')
-    mock_nexus_sim._wells.load() # Manually call load_wells to simulate loading in wells before we change the open mock.
+    mock_nexus_sim._wells._load() # Manually call load_wells to simulate loading in wells before we change the open mock.
     mock_nexus_sim.start_date = start_date
     remove_perf_dict = {'date': remove_perf_date, 'i': 4, 'j': 5, 'k': 6, 'well_radius': 4.2}
     well_files = mock_nexus_sim.model_files.well_files[1]


### PR DESCRIPTION
Also moving some properties up to the base `Wells` class from NexusWells and removing the requirement for the user to supply a date format when adding a completion.