### PR TITLE
Add model unit system to properties

### DIFF
--- a/ResSimpy/Nexus/NexusEquilMethods.py
+++ b/ResSimpy/Nexus/NexusEquilMethods.py
@@ -73,3 +73,7 @@ class NexusEquilMethods(Equilibration):
                                                                 model_unit_system=self.__model_unit_system)
                     self.__inputs[table_num].read_properties()  # Populate object with equil properties in file
         self.__properties_loaded = True
+
+    @property
+    def model_unit_system(self) -> UnitSystem:
+        return self.__model_unit_system


### PR DESCRIPTION
Adds unit system to accessible property for the Nexus Equil Methods to enable conversions.