### PR TITLE
Refactor fluid type identifier

### DIFF
--- a/ResSimpy/Nexus/NexusSimulator.py
+++ b/ResSimpy/Nexus/NexusSimulator.py
@@ -350,6 +350,7 @@ class NexusSimulator(Simulator):
     @staticmethod
     def get_fluid_type(surface_file_content: list[str]) -> str:
         """Gets the fluid type for a single model from a surface file.
+        Defaults to BLACKOIL if no explicit fluid type is found.
 
         Args:
             surface_file_content (str): list of strings with a new line per entry from the surface file

--- a/ResSimpy/OpenGoSim/OpenGoSimSimulator.py
+++ b/ResSimpy/OpenGoSim/OpenGoSimSimulator.py
@@ -213,7 +213,7 @@ WELLS
         self._wells._wells_loaded = True
 
     @staticmethod
-    def get_fluid_type(surface_file_name: str) -> str:
+    def get_fluid_type(surface_file_content: list[str]) -> str:
         raise NotImplementedError("Not implemented for OGS yet")
 
     def set_output_path(self, path: str) -> None:

--- a/ResSimpy/Simulator.py
+++ b/ResSimpy/Simulator.py
@@ -140,7 +140,7 @@ class Simulator(ABC):
 
     @staticmethod
     @abstractmethod
-    def get_fluid_type(surface_file_name: str) -> str:
+    def get_fluid_type(surface_file_content: list[str]) -> str:
         raise NotImplementedError("This method has not been implemented for this simulator yet")
 
     @abstractmethod


### PR DESCRIPTION
Change behaviour for default of fluid type in file and adds tests for finding fluid types from files. Raises warning and sets default for no explicit oil and gas types.