### PR TITLE
Fix load wells with decimal times

### DIFF
--- a/ResSimpy/Nexus/DataModels/NexusCompletion.py
+++ b/ResSimpy/Nexus/DataModels/NexusCompletion.py
@@ -375,13 +375,14 @@ class NexusCompletion(Completion):
     @classmethod
     def from_dict(cls, input_dictionary: dict[str, None | float | int | str], date_format: DateFormat) -> Self:
         """Generates a NexusCompletion from a dictionary."""
+        skip_mapping_keys = ['date', 'date_format', 'unit_system', 'start_date']
         for input_attr in input_dictionary:
-            if input_attr == 'date' or input_attr == 'unit_system' or input_attr == 'date_format':
+            if input_attr in skip_mapping_keys:
                 continue
             elif input_attr not in cls.valid_attributes():
                 raise AttributeError(f'Unexpected keyword "{input_attr}" found within {input_dictionary}')
         date = input_dictionary.get('date', None)
-        date_format_str = input_dictionary.get('date_format')
+        date_format_str = input_dictionary.get('date_format', None)
         if date_format_str is not None and isinstance(date_format_str, str):
             converted_date_format_str = date_format_str.replace('/', '_')
             completion_date_format = DateFormat[converted_date_format_str]

--- a/ResSimpy/Nexus/DataModels/NexusWell.py
+++ b/ResSimpy/Nexus/DataModels/NexusWell.py
@@ -1,6 +1,6 @@
 """Class for representing a well in Nexus. Consists of a list of completions and a well name."""
 from __future__ import annotations
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Optional, Sequence, Union, TYPE_CHECKING
 from uuid import UUID
 
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 class NexusWell(Well):
     """Class for representing a well in Nexus. Consists of a list of completions and a well name."""
     _wellmods: list[NexusWellMod]
-    _parent_wells_instance: NexusWells
+    _parent_wells_instance: NexusWells = field(compare=False)
 
     def __init__(self, well_name: str, completions: Sequence[NexusCompletion], unit_system: UnitSystem,
                  parent_wells_instance: NexusWells, wellmods: Sequence[NexusWellMod] | None = None,

--- a/ResSimpy/Nexus/DataModels/NexusWell.py
+++ b/ResSimpy/Nexus/DataModels/NexusWell.py
@@ -138,6 +138,7 @@ class NexusWell(Well):
         """
         completion_properties['date'] = date
         completion_properties['unit_system'] = self.unit_system
+        completion_properties['start_date'] = self._parent_wells_instance.start_date
         new_completion = NexusCompletion.from_dict(completion_properties, date_format)
         if completion_index is None:
             completion_index = len(self._completions)

--- a/ResSimpy/Nexus/NexusWells.py
+++ b/ResSimpy/Nexus/NexusWells.py
@@ -36,7 +36,7 @@ class NexusWells(Wells):
         model (Simulator): NexusSimulator object that has the instance of wells on.
     """
     __model: NexusSimulator = field(compare=False)
-    __date_format: DateFormat
+    __date_format: DateFormat = field(repr=False)
     _wells: list[NexusWell] = field(default_factory=list)
 
     def __init__(self, model: NexusSimulator) -> None:
@@ -53,6 +53,10 @@ class NexusWells(Wells):
     def model(self) -> NexusSimulator:
         """The model object that contains this NexusWells instance."""
         return self.__model
+
+    @property
+    def start_date(self) -> str:
+        return self.__model.start_date
 
     @property
     def date_format(self) -> DateFormat:

--- a/ResSimpy/Nexus/NexusWells.py
+++ b/ResSimpy/Nexus/NexusWells.py
@@ -35,7 +35,7 @@ class NexusWells(Wells):
     Arguments:
         model (Simulator): NexusSimulator object that has the instance of wells on.
     """
-    __model: NexusSimulator
+    __model: NexusSimulator = field(compare=False)
     __date_format: DateFormat
     _wells: list[NexusWell] = field(default_factory=list)
 

--- a/ResSimpy/Nexus/load_wells.py
+++ b/ResSimpy/Nexus/load_wells.py
@@ -227,7 +227,7 @@ def load_wells(nexus_file: NexusFile, start_date: str, default_units: UnitSystem
             # Load in each line of the table
             completions = __load_wellspec_table_completions(
                 nexus_file, header_index, header_values, headers, current_date, end_point_scaling_header_values,
-                date_format, unit_system=wellspec_file_units)
+                date_format, unit_system=wellspec_file_units, start_date=start_date)
 
             if well_name.upper() in well_name_list:
                 wells[well_name_list.index(well_name.upper())].completions.extend(completions)
@@ -246,6 +246,7 @@ def __load_wellspec_table_completions(nexus_file: NexusFile, header_index: int,
                                       end_point_scaling_header_values: dict[str, None | int | float | str],
                                       date_format: DateFormat,
                                       unit_system: UnitSystem,
+                                      start_date: None | str = None,
                                       ) -> list[NexusCompletion]:
     """Loads a completion table in for a single WELLSPEC keyword. \
         Loads in the next available completions following a WELLSPEC keyword and a header line.
@@ -256,6 +257,11 @@ def __load_wellspec_table_completions(nexus_file: NexusFile, header_index: int,
             headings to populate from the table
         headers (list[str]): list of strings containing the headers from the wellspec table
         date (str): date to populate the completion class with.
+        end_point_scaling_header_values (dict): dictionary containing the header values for thes special end point
+        scaling columns.
+        date_format (DateFormat): date format as a DateFormat Enum to use for the completion.
+        unit_system (UnitSystem): unit system as a UnitSystem Enum to use for the completion.
+        start_date (Optional[str]): start date of the model.
 
     Returns:
         list[NexusCompletion]: list of nexus completions for a given table.
@@ -350,6 +356,7 @@ def __load_wellspec_table_completions(nexus_file: NexusFile, header_index: int,
             kh_mult=convert_header_value_float('KHMULT'),
             date_format=date_format,
             unit_system=unit_system,
+            start_date=start_date,
         )
 
         nexus_file.add_object_locations(new_completion.id, [index + header_index + 1])

--- a/ResSimpy/Nexus/nexus_add_new_object_to_file.py
+++ b/ResSimpy/Nexus/nexus_add_new_object_to_file.py
@@ -100,8 +100,11 @@ class AddObjectOperations:
         header_index, headers = nfo.get_table_header(file_as_list=table, header_values=keyword_map)
         header_index += index
         headers_original = copy.copy(headers)
+
+        keys_to_skip = ['date', 'unit_system', 'date_format', 'start_date']
+
         for key in object_properties:
-            if key == 'date' or key == 'unit_system' or key == 'date_format':
+            if key in keys_to_skip:
                 continue
             if inverted_nexus_map[key] not in headers:
                 headers.append(inverted_nexus_map[key])

--- a/tests/Nexus/date_format_tests/test_multiple_date_formats.py
+++ b/tests/Nexus/date_format_tests/test_multiple_date_formats.py
@@ -23,10 +23,11 @@ def test_load_wells_multiple_dates_formats_DD_MM_YYYY_h_m_s(mocker):
     """
 
     expected_well_1_completion_1 = NexusCompletion(date='31/08/2023(19:13:01)', i=1, j=2, k=3, well_radius=4.5,
-                                                   date_format=date_format, unit_system=UnitSystem.ENGLISH)
+                                                   date_format=date_format, unit_system=UnitSystem.ENGLISH,
+                                                   start_date=start_date)
     expected_well_1_completion_2 = NexusCompletion(date='31/08/2023(19:13:01)', i=6, j=7, k=8, well_radius=9.11,
-                                                   date_format=date_format, unit_system=UnitSystem.ENGLISH)
-    
+                                                   date_format=date_format, unit_system=UnitSystem.ENGLISH,
+                                                   start_date=start_date)
 
     dummy_model = get_fake_nexus_simulator(mocker)
     dummy_wells = NexusWells(model=dummy_model)
@@ -34,7 +35,7 @@ def test_load_wells_multiple_dates_formats_DD_MM_YYYY_h_m_s(mocker):
     expected_well_1 = NexusWell(well_name='DEV1',
                                 completions=[expected_well_1_completion_1, expected_well_1_completion_2],
                                 unit_system=UnitSystem.ENGLISH, parent_wells_instance=dummy_wells)
-    
+
     expected_wells = [expected_well_1]
 
     open_mock = mocker.mock_open(read_data=file_contents)
@@ -47,7 +48,8 @@ def test_load_wells_multiple_dates_formats_DD_MM_YYYY_h_m_s(mocker):
 
     # Assert
     assert result_wells == expected_wells
-    
+
+
 def test_load_wells_multiple_dates_formats_MM_DD_YYYY_h_m_s(mocker):
     # Arrange
     start_date = '01/01/2023'
@@ -63,10 +65,11 @@ def test_load_wells_multiple_dates_formats_MM_DD_YYYY_h_m_s(mocker):
     """
 
     expected_well_1_completion_1 = NexusCompletion(date='10/24/2023(19:13:01)', i=1, j=2, k=3, well_radius=4.5,
-                                                   date_format=date_format, unit_system=UnitSystem.ENGLISH)
+                                                   date_format=date_format, unit_system=UnitSystem.ENGLISH,
+                                                   start_date=start_date)
     expected_well_1_completion_2 = NexusCompletion(date='10/24/2023(19:13:01)', i=6, j=7, k=8, well_radius=9.11,
-                                                   date_format=date_format, unit_system=UnitSystem.ENGLISH)
-    
+                                                   date_format=date_format, unit_system=UnitSystem.ENGLISH,
+                                                   start_date=start_date)
 
     dummy_model = get_fake_nexus_simulator(mocker)
     dummy_wells = NexusWells(model=dummy_model)
@@ -74,7 +77,7 @@ def test_load_wells_multiple_dates_formats_MM_DD_YYYY_h_m_s(mocker):
     expected_well_1 = NexusWell(well_name='DEV1',
                                 completions=[expected_well_1_completion_1, expected_well_1_completion_2],
                                 unit_system=UnitSystem.ENGLISH, parent_wells_instance=dummy_wells)
-    
+
     expected_wells = [expected_well_1]
 
     open_mock = mocker.mock_open(read_data=file_contents)
@@ -87,7 +90,8 @@ def test_load_wells_multiple_dates_formats_MM_DD_YYYY_h_m_s(mocker):
 
     # Assert
     assert result_wells == expected_wells
-    
+
+
 def test_load_wells_multiple_dates_formats_DD_MM_YYYY_with_time_added(mocker):
     # Arrange
     start_date = '01/01/2023'
@@ -103,10 +107,11 @@ def test_load_wells_multiple_dates_formats_DD_MM_YYYY_with_time_added(mocker):
     """
 
     expected_well_1_completion_1 = NexusCompletion(date='31/08/2023(19:13:01)', i=1, j=2, k=3, well_radius=4.5,
-                                                   date_format=date_format, unit_system=UnitSystem.ENGLISH)
+                                                   date_format=date_format, unit_system=UnitSystem.ENGLISH,
+                                                   start_date=start_date)
     expected_well_1_completion_2 = NexusCompletion(date='31/08/2023(19:13:01)', i=6, j=7, k=8, well_radius=9.11,
-                                                   date_format=date_format, unit_system=UnitSystem.ENGLISH)
-    
+                                                   date_format=date_format, unit_system=UnitSystem.ENGLISH,
+                                                   start_date=start_date)
 
     dummy_model = get_fake_nexus_simulator(mocker)
     dummy_wells = NexusWells(model=dummy_model)
@@ -114,7 +119,7 @@ def test_load_wells_multiple_dates_formats_DD_MM_YYYY_with_time_added(mocker):
     expected_well_1 = NexusWell(well_name='DEV1',
                                 completions=[expected_well_1_completion_1, expected_well_1_completion_2],
                                 unit_system=UnitSystem.ENGLISH, parent_wells_instance=dummy_wells)
-    
+
     expected_wells = [expected_well_1]
 
     open_mock = mocker.mock_open(read_data=file_contents)
@@ -127,7 +132,8 @@ def test_load_wells_multiple_dates_formats_DD_MM_YYYY_with_time_added(mocker):
 
     # Assert
     assert result_wells == expected_wells
-    
+
+
 def test_load_wells_multiple_dates_formats_MM_DD_YYYY_with_time_added(mocker):
     # Arrange
     start_date = '01/01/2023'
@@ -143,10 +149,11 @@ def test_load_wells_multiple_dates_formats_MM_DD_YYYY_with_time_added(mocker):
     """
 
     expected_well_1_completion_1 = NexusCompletion(date='10/24/2023(19:13:01)', i=1, j=2, k=3, well_radius=4.5,
-                                                   date_format=date_format, unit_system=UnitSystem.ENGLISH)
+                                                   date_format=date_format, unit_system=UnitSystem.ENGLISH,
+                                                   start_date=start_date)
     expected_well_1_completion_2 = NexusCompletion(date='10/24/2023(19:13:01)', i=6, j=7, k=8, well_radius=9.11,
-                                                   date_format=date_format, unit_system=UnitSystem.ENGLISH)
-    
+                                                   date_format=date_format, unit_system=UnitSystem.ENGLISH,
+                                                   start_date=start_date)
 
     dummy_model = get_fake_nexus_simulator(mocker)
     dummy_wells = NexusWells(model=dummy_model)
@@ -154,7 +161,7 @@ def test_load_wells_multiple_dates_formats_MM_DD_YYYY_with_time_added(mocker):
     expected_well_1 = NexusWell(well_name='DEV1',
                                 completions=[expected_well_1_completion_1, expected_well_1_completion_2],
                                 unit_system=UnitSystem.ENGLISH, parent_wells_instance=dummy_wells)
-    
+
     expected_wells = [expected_well_1]
 
     open_mock = mocker.mock_open(read_data=file_contents)

--- a/tests/Nexus/nexus_simulator/test_nexus_network.py
+++ b/tests/Nexus/nexus_simulator/test_nexus_network.py
@@ -1,4 +1,3 @@
-
 import numpy as np
 import pandas as pd
 import pytest
@@ -24,19 +23,20 @@ from tests.multifile_mocker import mock_multiple_files
 from tests.utility_for_tests import get_fake_nexus_simulator
 
 
-@pytest.mark.parametrize('file_contents, node1_props, node2_props',[
-('''NODES
+@pytest.mark.parametrize('file_contents, node1_props, node2_props', [
+    ('''NODES
   NAME                           TYPE       DEPTH   TEMP
  ! Riser Nodes
   node1                         NA            NA      #
   node_2        WELLHEAD     1167.3 # 
   ENDNODES
 ''',
-{'name': 'node1', 'type': None, 'depth': None,  'temp': None, 'date': '01/01/2023', 'unit_system': UnitSystem.ENGLISH},
-{'name': 'node_2', 'type': 'WELLHEAD', 'depth': 1167.3, 'temp': None, 'date': '01/01/2023',
-    'unit_system': UnitSystem.ENGLISH}
-    ),
-('''NODES
+     {'name': 'node1', 'type': None, 'depth': None, 'temp': None, 'date': '01/01/2023',
+      'unit_system': UnitSystem.ENGLISH},
+     {'name': 'node_2', 'type': 'WELLHEAD', 'depth': 1167.3, 'temp': None, 'date': '01/01/2023',
+      'unit_system': UnitSystem.ENGLISH}
+     ),
+    ('''NODES
   NAME       TYPE       DEPTH   TemP    X     Y       NUMBER  StatiON
  ! Riser Nodes
   node1         NA        NA    60.5    100.5 300.5   1     station
@@ -45,12 +45,13 @@ from tests.utility_for_tests import get_fake_nexus_simulator
   content outside of the node statement
   node1         NA        NA    60.5    10.5 3.5   1     station_null
   ''',
-{'name': 'node1', 'type': None, 'depth': None, 'temp': 60.5, 'x_pos': 100.5, 'y_pos': 300.5, 'number': 1,
-    'station': 'station', 'date': '01/01/2023', 'unit_system': UnitSystem.ENGLISH},
-{'name': 'node_2', 'type': 'WELLHEAD', 'depth': 1167.3, 'temp': None, 'x_pos': 10.21085, 'y_pos': 3524.23, 'number': 2,
-    'station': 'station2', 'date': '01/01/2023', 'unit_system': UnitSystem.ENGLISH}
-  ),
-('''NODES
+     {'name': 'node1', 'type': None, 'depth': None, 'temp': 60.5, 'x_pos': 100.5, 'y_pos': 300.5, 'number': 1,
+      'station': 'station', 'date': '01/01/2023', 'unit_system': UnitSystem.ENGLISH},
+     {'name': 'node_2', 'type': 'WELLHEAD', 'depth': 1167.3, 'temp': None, 'x_pos': 10.21085, 'y_pos': 3524.23,
+      'number': 2,
+      'station': 'station2', 'date': '01/01/2023', 'unit_system': UnitSystem.ENGLISH}
+     ),
+    ('''NODES
   NAME                           TYPE       DEPTH   TEMP
  ! Riser Nodes
   node1                         NA            NA      #
@@ -62,11 +63,12 @@ from tests.utility_for_tests import get_fake_nexus_simulator
   node_2        WELLHEAD     1167.3 # 
   ENDNODES
 ''',
-{'name': 'node1', 'type': None, 'depth': None,  'temp': None, 'date': '01/01/2023', 'unit_system': UnitSystem.ENGLISH},
-{'name': 'node_2', 'type': 'WELLHEAD', 'depth': 1167.3, 'temp': None, 'date': '01/02/2023',
-    'unit_system': UnitSystem.ENGLISH}
-    ),
-('''NODES
+     {'name': 'node1', 'type': None, 'depth': None, 'temp': None, 'date': '01/01/2023',
+      'unit_system': UnitSystem.ENGLISH},
+     {'name': 'node_2', 'type': 'WELLHEAD', 'depth': 1167.3, 'temp': None, 'date': '01/02/2023',
+      'unit_system': UnitSystem.ENGLISH}
+     ),
+    ('''NODES
   NAME                           TYPE       DEPTH   TEMP
  ! Riser Nodes
   node1                         NA            NA      #
@@ -79,11 +81,12 @@ from tests.utility_for_tests import get_fake_nexus_simulator
   node_2        WELLHEAD     1167.3 # 
   ENDNODES
 ''',
-{'name': 'node1', 'type': None, 'depth': None,  'temp': None, 'date': '01/01/2023', 'unit_system': UnitSystem.ENGLISH},
-{'name': 'node_2', 'type': 'WELLHEAD', 'depth': 1167.3, 'temp': None, 'date': '01/02/2023',
-    'unit_system': UnitSystem.METRIC}
-    ),
-('''NODES
+     {'name': 'node1', 'type': None, 'depth': None, 'temp': None, 'date': '01/01/2023',
+      'unit_system': UnitSystem.ENGLISH},
+     {'name': 'node_2', 'type': 'WELLHEAD', 'depth': 1167.3, 'temp': None, 'date': '01/02/2023',
+      'unit_system': UnitSystem.METRIC}
+     ),
+    ('''NODES
   NAME       TYPE       DEPTH   TemP    X     Y       NUMBER  StatiON
  ! Riser Nodes
   node1         NA        NA    60.5    100.5 300.5   1     station
@@ -95,14 +98,13 @@ ENDNODES
   content outside of the node statement
   node1         NA        NA    60.5    10.5 3.5   1     station_null
   ''',
-{'name': 'node1', 'type': None, 'depth': None, 'temp': 60.5, 'x_pos': 100.5, 'y_pos': 300.5, 'number': 1,
-    'station': 'station', 'date': '01/01/2023', 'unit_system': UnitSystem.ENGLISH},
-{'name': 'node_2', 'type': 'WELLHEAD', 'depth': 1167.3, 'temp': None, 'x_pos': None, 'y_pos': None, 'number': 2,
-    'station': 'station2', 'date': '01/01/2023', 'unit_system': UnitSystem.ENGLISH}
-  ),
+     {'name': 'node1', 'type': None, 'depth': None, 'temp': 60.5, 'x_pos': 100.5, 'y_pos': 300.5, 'number': 1,
+      'station': 'station', 'date': '01/01/2023', 'unit_system': UnitSystem.ENGLISH},
+     {'name': 'node_2', 'type': 'WELLHEAD', 'depth': 1167.3, 'temp': None, 'x_pos': None, 'y_pos': None, 'number': 2,
+      'station': 'station2', 'date': '01/01/2023', 'unit_system': UnitSystem.ENGLISH}
+     ),
 
-
-('''TIME 01/01/2023
+    ('''TIME 01/01/2023
   TIME 01/01/2024
 NODES
   NAME          TEMP    TYPE
@@ -115,12 +117,13 @@ NODES
   test_node3 WELLHEAD 1167.3 100 100 ! NODES
 ENDNODES
 ''',
-{'name': 'test_node2', 'type': 'WELL', 'temp': 100, 'date': '01/01/2024', 'unit_system': UnitSystem.ENGLISH},
-{'name': 'test_node3', 'type': 'WELLHEAD', 'depth': 1167.3, 'x_pos': 100, 'y_pos': 100, 'date': '01/01/2025', 'unit_system': UnitSystem.ENGLISH},
-)
+     {'name': 'test_node2', 'type': 'WELL', 'temp': 100, 'date': '01/01/2024', 'unit_system': UnitSystem.ENGLISH},
+     {'name': 'test_node3', 'type': 'WELLHEAD', 'depth': 1167.3, 'x_pos': 100, 'y_pos': 100, 'date': '01/01/2025',
+      'unit_system': UnitSystem.ENGLISH},
+     )
 ],
-ids=['basic', 'all columns', 'times', 'units', 'two tables', 'keyword in column']
-)
+                         ids=['basic', 'all columns', 'times', 'units', 'two tables', 'keyword in column']
+                         )
 def test_load_nexus_nodes(mocker, file_contents, node1_props, node2_props):
     # Arrange
     # mock out a surface file:
@@ -149,8 +152,8 @@ def test_load_nexus_nodes(mocker, file_contents, node1_props, node2_props):
         assert single_node_result.depth / 2 == 1167.3 / 2
 
 
-@pytest.mark.parametrize('file_contents, node1_props, node2_props',[
-('''NODES
+@pytest.mark.parametrize('file_contents, node1_props, node2_props', [
+    ('''NODES
   NAME       TYPE       DEPTH   TemP    X     Y       NUMBER  StatiON
  ! Riser Nodes
   node1         NA        NA    60.5    100.5 300.5   1     station
@@ -159,11 +162,12 @@ def test_load_nexus_nodes(mocker, file_contents, node1_props, node2_props):
   content outside of the node statement
   node1         NA        NA    60.5    10.5 3.5   1     station_null
   ''',
-{'name': 'node1', 'type': None, 'depth': None, 'temp': 60.5, 'x_pos': 100.5, 'y_pos': 300.5, 'number': 1,
-    'station': 'station', 'date': '01/01/2023', 'unit_system': 'ENGLISH'},
-{'name': 'node_2', 'type': 'WELLHEAD', 'depth': 1167.3, 'temp': None, 'x_pos': 10.21085, 'y_pos': 3524.23, 'number': 2,
-    'station': 'station2', 'date': '01/01/2023', 'unit_system': 'ENGLISH'}
-  )],)
+     {'name': 'node1', 'type': None, 'depth': None, 'temp': 60.5, 'x_pos': 100.5, 'y_pos': 300.5, 'number': 1,
+      'station': 'station', 'date': '01/01/2023', 'unit_system': 'ENGLISH'},
+     {'name': 'node_2', 'type': 'WELLHEAD', 'depth': 1167.3, 'temp': None, 'x_pos': 10.21085, 'y_pos': 3524.23,
+      'number': 2,
+      'station': 'station2', 'date': '01/01/2023', 'unit_system': 'ENGLISH'}
+     )], )
 def test_get_node_df(mocker, file_contents, node1_props, node2_props):
     # Arrange
     start_date = '01/01/2023'
@@ -179,20 +183,21 @@ def test_get_node_df(mocker, file_contents, node1_props, node2_props):
     result = nexus_nodes.get_df()
 
     # Assert
-    pd.testing.assert_frame_equal(result, expected_df,)
+    pd.testing.assert_frame_equal(result, expected_df, )
 
-@pytest.mark.parametrize('file_contents, connection1_props, connection2_props',[
-('''NODECON
+
+@pytest.mark.parametrize('file_contents, connection1_props, connection2_props', [
+    ('''NODECON
 	NAME            NODEIN    NODEOUT       TYPE        METHOD    DDEPTH
 	CP01            CP01      wh_cp01       PIPE        2          7002.67
 	cp01_gaslift    GAS       CP01          GASLIFT     NONE        NA ! Checked NODECON 13/05/2020 
 	ENDNODECON
 	''',
-	{'name': 'CP01', 'node_in': 'CP01', 'node_out': 'wh_cp01', 'con_type': 'PIPE', 'hyd_method': '2',
-	'delta_depth': 7002.67, 'date': '01/01/2023', 'unit_system': UnitSystem.ENGLISH},
-	{'name': 'cp01_gaslift', 'node_in': 'GAS', 'node_out': 'CP01', 'con_type': 'GASLIFT', 'hyd_method': None,
-	'delta_depth': None, 'date': '01/01/2023', 'unit_system': UnitSystem.ENGLISH},),
-(	'''NODES
+     {'name': 'CP01', 'node_in': 'CP01', 'node_out': 'wh_cp01', 'con_type': 'PIPE', 'hyd_method': '2',
+      'delta_depth': 7002.67, 'date': '01/01/2023', 'unit_system': UnitSystem.ENGLISH},
+     {'name': 'cp01_gaslift', 'node_in': 'GAS', 'node_out': 'CP01', 'con_type': 'GASLIFT', 'hyd_method': None,
+      'delta_depth': None, 'date': '01/01/2023', 'unit_system': UnitSystem.ENGLISH},),
+    ('''NODES
   NAME       TYPE       DEPTH   TemP    X     Y       NUMBER  StatiON
  ! Riser Nodes
   node1         NA        NA    60.5    100.5 300.5   1     station
@@ -203,11 +208,11 @@ def test_get_node_df(mocker, file_contents, node1_props, node2_props):
 	CP01            CP01      wh_cp01       PIPE        2          7002.67  20486
 	cp01_gaslift    GAS       CP01          GASLIFT     NONE        NA    1000.23! Checked NODECON 13/05/2020 
 	ENDNODECON''',
-    {'name': 'CP01', 'node_in': 'CP01', 'node_out': 'wh_cp01', 'con_type': 'PIPE', 'hyd_method': '2',
-    'delta_depth': 7002.67, 'dp_add': 20486, 'date': '01/01/2023', 'unit_system': UnitSystem.ENGLISH},
-    {'name': 'cp01_gaslift', 'node_in': 'GAS', 'node_out': 'CP01', 'con_type': 'GASLIFT', 'hyd_method': None,
-    'delta_depth': None, 'dp_add': 1000.23, 'date': '01/01/2023', 'unit_system': UnitSystem.ENGLISH},),
-(	''' TIME 01/02/2023
+     {'name': 'CP01', 'node_in': 'CP01', 'node_out': 'wh_cp01', 'con_type': 'PIPE', 'hyd_method': '2',
+      'delta_depth': 7002.67, 'dp_add': 20486, 'date': '01/01/2023', 'unit_system': UnitSystem.ENGLISH},
+     {'name': 'cp01_gaslift', 'node_in': 'GAS', 'node_out': 'CP01', 'con_type': 'GASLIFT', 'hyd_method': None,
+      'delta_depth': None, 'dp_add': 1000.23, 'date': '01/01/2023', 'unit_system': UnitSystem.ENGLISH},),
+    (''' TIME 01/02/2023
   NODECON
 	NAME            NODEIN    NODEOUT       TYPE        METHOD    DDEPTH
 	CP01            CP01      wh_cp01       PIPE        2          7002.67
@@ -217,24 +222,27 @@ def test_get_node_df(mocker, file_contents, node1_props, node2_props):
 		NAME            NODEIN    NODEOUT       TYPE        METHOD    DDEPTH
 	cp01_gaslift    GAS       CP01          GASLIFT     NONE        NA ! Checked NODECON 13/05/2020 
 	ENDNODECON''',
-    {'name': 'CP01', 'node_in': 'CP01', 'node_out': 'wh_cp01', 'con_type': 'PIPE', 'hyd_method': '2',
-    'delta_depth': 7002.67, 'date': '01/02/2023', 'unit_system': UnitSystem.ENGLISH},
-    {'name': 'cp01_gaslift', 'node_in': 'GAS', 'node_out': 'CP01', 'con_type': 'GASLIFT', 'hyd_method': None,
-    'delta_depth': None, 'date': '01/03/2023', 'unit_system': UnitSystem.ENGLISH},),
-('''NODECON
+     {'name': 'CP01', 'node_in': 'CP01', 'node_out': 'wh_cp01', 'con_type': 'PIPE', 'hyd_method': '2',
+      'delta_depth': 7002.67, 'date': '01/02/2023', 'unit_system': UnitSystem.ENGLISH},
+     {'name': 'cp01_gaslift', 'node_in': 'GAS', 'node_out': 'CP01', 'con_type': 'GASLIFT', 'hyd_method': None,
+      'delta_depth': None, 'date': '01/03/2023', 'unit_system': UnitSystem.ENGLISH},),
+    ('''NODECON
   NAME    NODEIN        NODEOUT       TYPE      METHOD    IPVT  ELEVPR   MDIN     MDOUT DIAM  ROUGHNESS    HTC  TEMPPR    TEMPIN  TEMPOUT
   CP01   dccfr1        pseudo_prd_1  PIPE      HAG_BEG     NA  R0302E04 NA        NA   9.500    0.0476  8.000  prtempr    100.3     300
   prd_2   pseudo_prd_1  pseudo_prd_2  PIPE      HAG_BEG     NA  R0308E03 NA        NA   9.130    0.0018  8.000  prtempr   100     10.3
 !prd_3   prd_3         prd_3         PIPE      HAG_BEG     NA  R0308E03 NA        NA   9.130    0.0018  8.000  prtempr    200     NA
   ENDNODECON''',
-    {'name': 'CP01', 'node_in': 'dccfr1', 'node_out': 'pseudo_prd_1', 'con_type': 'PIPE', 'hyd_method': 'HAG_BEG',
-    'elevation_profile': 'R0302E04','diameter': 9.500, 'roughness':0.0476, 'heat_transfer_coeff': 8.000,
-    'temperature_profile': 'prtempr', 'temperature_in': 100.3, 'temperature_out': 300, 'date': '01/01/2023', 'unit_system': UnitSystem.ENGLISH},
-    {'name': 'prd_2', 'node_in': 'pseudo_prd_1', 'node_out': 'pseudo_prd_2', 'con_type': 'PIPE', 'hyd_method': 'HAG_BEG',
-    'elevation_profile': 'R0308E03', 'diameter': 9.130, 'roughness':0.0018, 'heat_transfer_coeff':8.000,
-    'temperature_profile': 'prtempr', 'temperature_in': 100, 'temperature_out': 10.3, 'date': '01/01/2023', 'unit_system': UnitSystem.ENGLISH},),
+     {'name': 'CP01', 'node_in': 'dccfr1', 'node_out': 'pseudo_prd_1', 'con_type': 'PIPE', 'hyd_method': 'HAG_BEG',
+      'elevation_profile': 'R0302E04', 'diameter': 9.500, 'roughness': 0.0476, 'heat_transfer_coeff': 8.000,
+      'temperature_profile': 'prtempr', 'temperature_in': 100.3, 'temperature_out': 300, 'date': '01/01/2023',
+      'unit_system': UnitSystem.ENGLISH},
+     {'name': 'prd_2', 'node_in': 'pseudo_prd_1', 'node_out': 'pseudo_prd_2', 'con_type': 'PIPE',
+      'hyd_method': 'HAG_BEG',
+      'elevation_profile': 'R0308E03', 'diameter': 9.130, 'roughness': 0.0018, 'heat_transfer_coeff': 8.000,
+      'temperature_profile': 'prtempr', 'temperature_in': 100, 'temperature_out': 10.3, 'date': '01/01/2023',
+      'unit_system': UnitSystem.ENGLISH},),
 
-	], ids=['basic', 'other_tables', 'time changes two tables', 'More Columns'])
+], ids=['basic', 'other_tables', 'time changes two tables', 'More Columns'])
 def test_load_connections(mocker, file_contents, connection1_props, connection2_props):
     # Arrange
     start_date = '01/01/2023'
@@ -260,10 +268,11 @@ def test_load_connections(mocker, file_contents, connection1_props, connection2_
     # check for correct float types
     if single_connection_result.depth is not None:
         assert single_connection_result.depth / 2 == 7002.67 / 2
-    pd.testing.assert_frame_equal(result_df, expected_df,)
+    pd.testing.assert_frame_equal(result_df, expected_df, )
 
-@pytest.mark.parametrize('file_contents, well_connection_props1, well_connection_props2',[
-(''' TIME 02/10/2032
+
+@pytest.mark.parametrize('file_contents, well_connection_props1, well_connection_props2', [
+    (''' TIME 02/10/2032
 METRIC
 WELLS
   NAME    STREAM   NUMBER   DATUM   CROSSFLOW   CROSS_SHUT
@@ -272,13 +281,14 @@ WELLS
   bad_data
     ENDWELLS
 ''',
-{'name': 'prod', 'stream': 'PRODUCER', 'number': 94, 'datum_depth': 4039.3, 'crossflow': 'ON', 'crossshut': 'CELLGRAD',
-'date': '02/10/2032', 'unit_system': UnitSystem.METRIC},
-{'name': 'inj', 'stream': 'WATER', 'number': 95, 'datum_depth': 4039.3, 'crossflow': 'OFF', 'crossshut': 'CALC',
-'date': '02/10/2032', 'unit_system': UnitSystem.METRIC},
-)
+     {'name': 'prod', 'stream': 'PRODUCER', 'number': 94, 'datum_depth': 4039.3, 'crossflow': 'ON',
+      'crossshut': 'CELLGRAD',
+      'date': '02/10/2032', 'unit_system': UnitSystem.METRIC},
+     {'name': 'inj', 'stream': 'WATER', 'number': 95, 'datum_depth': 4039.3, 'crossflow': 'OFF', 'crossshut': 'CALC',
+      'date': '02/10/2032', 'unit_system': UnitSystem.METRIC},
+     )
 ])
-def test_load_well_connections(mocker, file_contents, well_connection_props1, well_connection_props2,):
+def test_load_well_connections(mocker, file_contents, well_connection_props1, well_connection_props2, ):
     # Arrange
     start_date = '01/01/2023'
     surface_file = NexusFile(location='surface.dat', file_content_as_list=file_contents.splitlines())
@@ -291,7 +301,6 @@ def test_load_well_connections(mocker, file_contents, well_connection_props1, we
     nexus_well_cons = NexusWellConnections(mock_nexus_network)
     expected_df = pd.DataFrame([well_connection_props1, well_connection_props2])
     expected_df = expected_df.fillna(value=np.nan).dropna(axis=1, how='all')
-
 
     # Act
     nexus_well_cons.load(surface_file, start_date, default_units=UnitSystem.ENGLISH)
@@ -353,16 +362,19 @@ DATEFORMAT DD/MM/YYYY
 RECURRENT_FILES
 	 WELLS Set 1        wells.dat
 	 SURFACE Network 1  surface.dat
+	 RUNCONTROL runcontrol.dat
 """
 
     def mock_open_wrapper(filename, mode):
         mock_open = mock_multiple_files(mocker, filename, potential_file_dict={
             'model.fcs': fcs_file_contents,
             'wells.dat': wellspec_file_contents,
-            'surface.dat': surface_file_contents
+            'surface.dat': surface_file_contents,
+            'runcontrol.dat': 'START 01/01/2018'
         }).return_value
         return mock_open
 
+    start_date = '01/01/2018'
     mocker.patch("builtins.open", mock_open_wrapper)
 
     model = get_fake_nexus_simulator(mocker=mocker, fcs_file_path='model.fcs', mock_open=False)
@@ -370,24 +382,40 @@ RECURRENT_FILES
     parent_wells_instance = NexusWells(model=model)
     model._wells = parent_wells_instance
 
-    expected_completion_1 = NexusCompletion(date='02/10/2032', i=1, j=2, k=3, well_radius=4.5, date_format=DateFormat.DD_MM_YYYY, unit_system=UnitSystem.ENGLISH)
-    expected_well_1 = NexusWell(well_name='well_prod_1', completions=[expected_completion_1], unit_system=UnitSystem.ENGLISH,
+    expected_completion_1 = NexusCompletion(date='02/10/2032', i=1, j=2, k=3, well_radius=4.5,
+                                            date_format=DateFormat.DD_MM_YYYY, unit_system=UnitSystem.ENGLISH,
+                                            start_date=start_date)
+    expected_well_1 = NexusWell(well_name='well_prod_1', completions=[expected_completion_1],
+                                unit_system=UnitSystem.ENGLISH,
                                 well_type=WellType.PRODUCER, parent_wells_instance=parent_wells_instance)
-    expected_completion_2 = NexusCompletion(date='02/10/2032', i=5, j=6, k=7, well_radius=8.0, date_format=DateFormat.DD_MM_YYYY, unit_system=UnitSystem.ENGLISH)
-    expected_well_2 = NexusWell(well_name='well_inj_wat', completions=[expected_completion_2], unit_system=UnitSystem.ENGLISH,
+    expected_completion_2 = NexusCompletion(date='02/10/2032', i=5, j=6, k=7, well_radius=8.0,
+                                            date_format=DateFormat.DD_MM_YYYY, unit_system=UnitSystem.ENGLISH,
+                                            start_date=start_date)
+    expected_well_2 = NexusWell(well_name='well_inj_wat', completions=[expected_completion_2],
+                                unit_system=UnitSystem.ENGLISH,
                                 well_type=WellType.WATER_INJECTOR, parent_wells_instance=parent_wells_instance)
-    expected_completion_3 = NexusCompletion(date='02/10/2032', i=9, j=10, k=11, well_radius=12.1, date_format=DateFormat.DD_MM_YYYY, unit_system=UnitSystem.ENGLISH)
-    expected_well_3 = NexusWell(well_name='well_inj_oil', completions=[expected_completion_3], unit_system=UnitSystem.ENGLISH,
+    expected_completion_3 = NexusCompletion(date='02/10/2032', i=9, j=10, k=11, well_radius=12.1,
+                                            date_format=DateFormat.DD_MM_YYYY, unit_system=UnitSystem.ENGLISH,
+                                            start_date=start_date)
+
+    expected_well_3 = NexusWell(well_name='well_inj_oil', completions=[expected_completion_3],
+                                unit_system=UnitSystem.ENGLISH,
                                 well_type=WellType.OIL_INJECTOR, parent_wells_instance=parent_wells_instance)
-    expected_completion_4 = NexusCompletion(date='02/10/2032', i=13, j=14, k=15, well_radius=16.0, date_format=DateFormat.DD_MM_YYYY, unit_system=UnitSystem.ENGLISH)
-    expected_well_4 = NexusWell(well_name='well_prod_2', completions=[expected_completion_4], unit_system=UnitSystem.ENGLISH,
+    expected_completion_4 = NexusCompletion(date='02/10/2032', i=13, j=14, k=15, well_radius=16.0,
+                                            date_format=DateFormat.DD_MM_YYYY, unit_system=UnitSystem.ENGLISH,
+                                            start_date=start_date)
+    expected_well_4 = NexusWell(well_name='well_prod_2', completions=[expected_completion_4],
+                                unit_system=UnitSystem.ENGLISH,
                                 well_type=WellType.PRODUCER, parent_wells_instance=parent_wells_instance)
-    expected_well_5 = NexusWell(well_name='well_inj_gas', completions=[expected_completion_4], unit_system=UnitSystem.ENGLISH,
+    expected_well_5 = NexusWell(well_name='well_inj_gas', completions=[expected_completion_4],
+                                unit_system=UnitSystem.ENGLISH,
                                 well_type=WellType.GAS_INJECTOR, parent_wells_instance=parent_wells_instance)
-    expected_well_6 = NexusWell(well_name='well_prod_other', completions=[expected_completion_4], unit_system=UnitSystem.ENGLISH,
+    expected_well_6 = NexusWell(well_name='well_prod_other', completions=[expected_completion_4],
+                                unit_system=UnitSystem.ENGLISH,
                                 well_type=WellType.PRODUCER, parent_wells_instance=parent_wells_instance)
 
-    expected_wells = [expected_well_1, expected_well_2, expected_well_3, expected_well_4, expected_well_5, expected_well_6]
+    expected_wells = [expected_well_1, expected_well_2, expected_well_3, expected_well_4, expected_well_5,
+                      expected_well_6]
 
     # Act
     result = model.wells.wells
@@ -398,15 +426,17 @@ RECURRENT_FILES
 
 
 @pytest.mark.parametrize('file_contents, wellhead_props_1, wellhead_props_2', [
-(''' TIME 01/03/2019
+    (''' TIME 01/03/2019
 WELLHEAD
 WELL NAME DEPTH TYPE METHOD
 !ru	TH-ru	100	PIPE 	3	
 R001	tubing	50.2	PIPE 	2	!ENDWELLHEAD
 R-0_02	TH-03	0	PIPE 	1! comment
 	ENDWELLHEAD''',
-{'well': 'R001', 'name': 'tubing', 'depth': 50.2, 'wellhead_type': 'PIPE', 'hyd_method': 2, 'date': '01/03/2019', 'unit_system': UnitSystem.ENGLISH},
-{'well': 'R-0_02', 'name': 'TH-03', 'depth': 0, 'wellhead_type': 'PIPE', 'hyd_method': 1, 'date': '01/03/2019', 'unit_system': UnitSystem.ENGLISH},)
+     {'well': 'R001', 'name': 'tubing', 'depth': 50.2, 'wellhead_type': 'PIPE', 'hyd_method': 2, 'date': '01/03/2019',
+      'unit_system': UnitSystem.ENGLISH},
+     {'well': 'R-0_02', 'name': 'TH-03', 'depth': 0, 'wellhead_type': 'PIPE', 'hyd_method': 1, 'date': '01/03/2019',
+      'unit_system': UnitSystem.ENGLISH},)
 
 ])
 def test_load_wellhead(mocker, file_contents, wellhead_props_1, wellhead_props_2):
@@ -434,8 +464,9 @@ def test_load_wellhead(mocker, file_contents, wellhead_props_1, wellhead_props_2
     assert single_wellhead == wellhead1
     pd.testing.assert_frame_equal(result_df, expected_df, check_like=True)
 
+
 @pytest.mark.parametrize('file_contents, wellboreprops1, wellboreprops2', [
-(''' TIME 01/03/2019
+    (''' TIME 01/03/2019
 WELLBORE
 WELL METHOD DIAM TYPE
 well1 BEGGS 3.5 PIPE
@@ -445,10 +476,10 @@ WELL METHOD DIAM FLOWSECT ROUGHNESS
 well2 BRILL 3.25 2      0.2002
 ENDWELLBORE
 	''',
-{'name': 'well1', 'bore_type': 'PIPE', 'hyd_method': "BEGGS", 'diameter': 3.5, 'date': '01/03/2019',
- 'unit_system': UnitSystem.ENGLISH},
-{'name': 'well2', 'hyd_method': "BRILL", 'diameter': 3.25, 'flowsect': 2, 'roughness': 0.2002,
- 'date': '01/03/2019', 'unit_system': UnitSystem.ENGLISH},)
+     {'name': 'well1', 'bore_type': 'PIPE', 'hyd_method': "BEGGS", 'diameter': 3.5, 'date': '01/03/2019',
+      'unit_system': UnitSystem.ENGLISH},
+     {'name': 'well2', 'hyd_method': "BRILL", 'diameter': 3.25, 'flowsect': 2, 'roughness': 0.2002,
+      'date': '01/03/2019', 'unit_system': UnitSystem.ENGLISH},)
 ])
 def test_load_wellbore(mocker, file_contents, wellboreprops1, wellboreprops2):
     # Arrange

--- a/tests/Nexus/nexus_simulator/test_nexus_simulator.py
+++ b/tests/Nexus/nexus_simulator/test_nexus_simulator.py
@@ -1892,7 +1892,7 @@ Run units: UnitSystem.ENGLISH
     test_data
     """, "GASWATER"),
     ("""EOS NHC 7 COMPONENTS C1 C2 C3 C4 C5 C6 C7+""",
-    "EOS NHC 7 COMPONENTS C1 C2 C3 C4 C5 C6 C7+"),
+     "EOS NHC 7 COMPONENTS C1 C2 C3 C4 C5 C6 C7+"),
     ("""test data filler
 ! comment
 EOS NHC 7

--- a/tests/Nexus/test_load_wells.py
+++ b/tests/Nexus/test_load_wells.py
@@ -64,9 +64,10 @@ def test_load_basic_wellspec(mocker, file_contents, expected_name):
     dummy_wells = NexusWells(model=dummy_model)
 
     expected_completion_1 = NexusCompletion(date=start_date, i=1, j=2, k=3, skin=None, well_radius=4.5, angle_v=None,
-                                            grid=None, date_format=date_format, unit_system=UnitSystem.ENGLISH)
+                                            grid=None, date_format=date_format, unit_system=UnitSystem.ENGLISH,
+                                            start_date=start_date)
     expected_completion_2 = NexusCompletion(date=start_date, i=6, j=7, k=8, well_radius=9.11, date_format=date_format,
-                                            unit_system=UnitSystem.ENGLISH)
+                                            unit_system=UnitSystem.ENGLISH, start_date=start_date)
     expected_well = NexusWell(well_name=expected_name, completions=[expected_completion_1, expected_completion_2],
                               unit_system=UnitSystem.ENGLISH, parent_wells_instance=dummy_wells)
 
@@ -124,28 +125,36 @@ WELLMOD	DEV2	DKH	CON	0
     """
 
     expected_well_1_completion_1 = NexusCompletion(date=start_date, i=1, j=2, k=3, well_radius=4.5,
-                                                   date_format=date_format, unit_system=UnitSystem.ENGLISH)
+                                                   date_format=date_format, unit_system=UnitSystem.ENGLISH,
+                                                   start_date=start_date)
     expected_well_1_completion_2 = NexusCompletion(date=start_date, i=6, j=7, k=8, well_radius=9.11,
-                                                   date_format=date_format, unit_system=UnitSystem.ENGLISH)
+                                                   date_format=date_format, unit_system=UnitSystem.ENGLISH,
+                                                   start_date=start_date)
 
     expected_well_2_completion_1 = NexusCompletion(date=start_date, i=12, j=12, k=13, well_radius=4.50000000000,
-                                                   date_format=date_format, unit_system=UnitSystem.ENGLISH)
+                                                   date_format=date_format, unit_system=UnitSystem.ENGLISH,
+                                                   start_date=start_date)
     expected_well_2_completion_2 = NexusCompletion(date=start_date, i=14, j=15, k=143243, well_radius=0.00002,
-                                                   date_format=date_format, unit_system=UnitSystem.ENGLISH)
+                                                   date_format=date_format, unit_system=UnitSystem.ENGLISH,
+                                                   start_date=start_date)
     expected_well_2_completion_3 = NexusCompletion(date=start_date, i=18, j=155, k=143243, well_radius=40.00002,
-                                                   date_format=date_format, unit_system=UnitSystem.ENGLISH)
+                                                   date_format=date_format, unit_system=UnitSystem.ENGLISH,
+                                                   start_date=start_date)
 
     expected_well_3_completion_1 = NexusCompletion(date=start_date, i=126, j=504, k=3, skin=0, well_radius=0.354,
                                                    partial_perf=1, date_format=date_format,
-                                                   unit_system=UnitSystem.ENGLISH)
+                                                   unit_system=UnitSystem.ENGLISH,
+                                                   start_date=start_date)
     expected_well_3_completion_2 = NexusCompletion(date=start_date, i=126, j=504, k=4, skin=0, well_radius=0.354,
                                                    partial_perf=1, date_format=date_format,
-                                                   unit_system=UnitSystem.ENGLISH)
+                                                   unit_system=UnitSystem.ENGLISH, start_date=start_date)
 
     expected_well_4_completion_1 = NexusCompletion(date=start_date, i=1, j=2, k=3, well_radius=4.5,
-                                                   date_format=date_format, unit_system=UnitSystem.ENGLISH)
+                                                   date_format=date_format, unit_system=UnitSystem.ENGLISH,
+                                                   start_date=start_date)
     expected_well_4_completion_2 = NexusCompletion(date=start_date, i=6, j=7, k=8, well_radius=9.11,
-                                                   date_format=date_format, unit_system=UnitSystem.ENGLISH)
+                                                   date_format=date_format, unit_system=UnitSystem.ENGLISH,
+                                                    start_date=start_date)
 
     dummy_model = get_fake_nexus_simulator(mocker)
     dummy_wells = NexusWells(model=dummy_model)
@@ -217,27 +226,37 @@ def test_load_wells_multiple_wells_multiple_dates(mocker):
     """
 
     expected_well_1_completion_1 = NexusCompletion(date='01/08/2023', i=1, j=2, k=3, well_radius=4.5,
-                                                   date_format=date_format, unit_system=UnitSystem.ENGLISH)
+                                                   date_format=date_format, unit_system=UnitSystem.ENGLISH,
+                                                   start_date=start_date)
     expected_well_1_completion_2 = NexusCompletion(date='01/08/2023', i=6, j=7, k=8, well_radius=9.11,
-                                                   date_format=date_format, unit_system=UnitSystem.ENGLISH)
+                                                   date_format=date_format, unit_system=UnitSystem.ENGLISH,
+                                                   start_date=start_date)
     expected_well_1_completion_3 = NexusCompletion(date='15/10/2023', i=4, j=8, k=6, well_radius=23.0,
-                                                   date_format=date_format, unit_system=UnitSystem.ENGLISH)
+                                                   date_format=date_format, unit_system=UnitSystem.ENGLISH,
+                                                   start_date=start_date)
     expected_well_1_completion_4 = NexusCompletion(date='15/10/2023', i=5, j=9, k=56, well_radius=37.23,
-                                                   date_format=date_format, unit_system=UnitSystem.ENGLISH)
+                                                   date_format=date_format, unit_system=UnitSystem.ENGLISH,
+                                                   start_date=start_date)
     expected_well_1_completion_5 = NexusCompletion(date='15/12/2023', i=1, j=2, k=4, perm_thickness_ovr=1.423,
                                                    peaceman_well_block_radius=1.55, date_format=date_format,
-                                                   unit_system=UnitSystem.ENGLISH)
+                                                   unit_system=UnitSystem.ENGLISH,
+                                                   start_date=start_date)
 
     expected_well_2_completion_1 = NexusCompletion(date='01/08/2023', i=12, j=12, k=13, well_radius=4.50000000000,
-                                                   date_format=date_format, unit_system=UnitSystem.ENGLISH)
+                                                   date_format=date_format, unit_system=UnitSystem.ENGLISH,
+                                                   start_date=start_date)
     expected_well_2_completion_2 = NexusCompletion(date='01/08/2023', i=14, j=15, k=143243, well_radius=0.00002,
-                                                   date_format=date_format, unit_system=UnitSystem.ENGLISH)
+                                                   date_format=date_format, unit_system=UnitSystem.ENGLISH,
+                                                   start_date=start_date)
     expected_well_2_completion_3 = NexusCompletion(date='01/08/2023', i=18, j=155, k=143243, well_radius=40.00002,
-                                                   date_format=date_format, unit_system=UnitSystem.ENGLISH)
+                                                   date_format=date_format, unit_system=UnitSystem.ENGLISH,
+                                                   start_date=start_date)
     expected_well_2_completion_4 = NexusCompletion(date='15/10/2023', i=15, j=28, k=684, well_radius=4.500000000001,
-                                                   date_format=date_format, unit_system=UnitSystem.ENGLISH)
+                                                   date_format=date_format, unit_system=UnitSystem.ENGLISH,
+                                                   start_date=start_date)
     expected_well_2_completion_5 = NexusCompletion(date='15/10/2023', i=18, j=63, k=1234, well_radius=1.00002,
-                                                   date_format=date_format, unit_system=UnitSystem.ENGLISH)
+                                                   date_format=date_format, unit_system=UnitSystem.ENGLISH,
+                                                   start_date=start_date)
 
     dummy_model = get_fake_nexus_simulator(mocker)
     dummy_wells = NexusWells(model=dummy_model)
@@ -286,13 +305,13 @@ def test_load_wells_all_columns_present_structured_grid(mocker):
                                                  depth_to_top=None, depth_to_top_str='TOP', depth_to_bottom_str='BOT',
                                                  depth_to_bottom=None, perm_thickness_ovr=1.23,
                                                  kh_mult=0.363, date_format=date_format, unit_system=UnitSystem.ENGLISH,
-                                                 peaceman_well_block_radius=1234)
+                                                 peaceman_well_block_radius=1234, start_date=start_date)
     expected_well_completion_2 = NexusCompletion(date='01/03/2023', i=6, j=7, k=8, skin=4.52, depth=8.955,
                                                  well_radius=9.11, x=9000.48974, y=2, angle_a=1, angle_v=5.68,
                                                  grid='GRID_B', measured_depth=1.568, well_indices=0.2874,
                                                  depth_to_top=0.2132, depth_to_bottom=5.45454, perm_thickness_ovr=4.56,
                                                  kh_mult=1.567, date_format=date_format, unit_system=UnitSystem.ENGLISH,
-                                                 peaceman_well_block_radius=1.589)
+                                                 peaceman_well_block_radius=1.589, start_date=start_date)
 
     dummy_model = get_fake_nexus_simulator(mocker)
     dummy_wells = NexusWells(model=dummy_model)
@@ -364,7 +383,7 @@ def test_load_wells_all_columns_unstructured_grid(mocker):
                                                  length=150.66, permeability=300.2, non_darcy_model='nondarcy',
                                                  comp_dz=0.5, layer_assignment=20, polymer_bore_radius=0.25,
                                                  polymer_well_radius=0.35, portype='FRACTURE', date_format=date_format,
-                                                 unit_system=UnitSystem.ENGLISH)
+                                                 unit_system=UnitSystem.ENGLISH, start_date=start_date)
 
     dummy_model = get_fake_nexus_simulator(mocker)
     dummy_wells = NexusWells(model=dummy_model)
@@ -412,11 +431,13 @@ def test_load_wells_rel_perm_tables(mocker):
 
     expected_well_completion_1 = NexusCompletion(date=start_date, cell_number=1,
                                                  rel_perm_end_point=expected_rel_perm_end_point_1,
-                                                 date_format=date_format, unit_system=UnitSystem.ENGLISH)
+                                                 date_format=date_format, unit_system=UnitSystem.ENGLISH,
+                                                 start_date=start_date)
 
     expected_well_completion_2 = NexusCompletion(date=start_date, cell_number=2,
                                                  rel_perm_end_point=expected_rel_perm_end_point_2,
-                                                 date_format=date_format, unit_system=UnitSystem.ENGLISH)
+                                                 date_format=date_format, unit_system=UnitSystem.ENGLISH,
+                                                 start_date=start_date)
 
     dummy_model = get_fake_nexus_simulator(mocker)
     dummy_wells = NexusWells(model=dummy_model)
@@ -457,15 +478,15 @@ def test_load_wells_na_values_converted_to_none(mocker):
     expected_well_completion_1 = NexusCompletion(date='01/03/2023', i=1, j=2, k=3, skin=8.9, depth=7.56,
                                                  well_radius=4.5, x=None, y=1.24, angle_a=0.98, angle_v=3,
                                                  grid='GRID_A', measured_depth=1.38974, date_format=date_format,
-                                                 unit_system=UnitSystem.ENGLISH)
+                                                 unit_system=UnitSystem.ENGLISH, start_date=start_date)
     expected_well_completion_2 = NexusCompletion(date='01/03/2023', i=6, j=None, k=8, skin=4.52, depth=8.955,
                                                  well_radius=None, x=9000.48974, y=2, angle_a=1, angle_v=5.68,
                                                  grid='GRID_B', measured_depth=1.568, date_format=date_format,
-                                                 unit_system=UnitSystem.ENGLISH)
+                                                 unit_system=UnitSystem.ENGLISH, start_date=start_date)
     expected_well_completion_3 = NexusCompletion(date='01/03/2023', i=None, j=None, k=None, skin=None, depth=None,
                                                  well_radius=None, x=None, y=None, angle_a=None, angle_v=None,
                                                  grid='NA', measured_depth=None, date_format=date_format,
-                                                 unit_system=UnitSystem.ENGLISH)
+                                                 unit_system=UnitSystem.ENGLISH, start_date=start_date)
 
     dummy_model = get_fake_nexus_simulator(mocker)
     dummy_wells = NexusWells(model=dummy_model)
@@ -547,9 +568,10 @@ def test_correct_units_loaded(mocker, file_contents, expected_units):
     date_format = DateFormat.DD_MM_YYYY
 
     expected_completion_1 = NexusCompletion(date=start_date, i=1, j=2, k=3, skin=None, well_radius=4.5, angle_v=None,
-                                            grid=None, date_format=date_format, unit_system=expected_units)
+                                            grid=None, date_format=date_format, unit_system=expected_units,
+                                            start_date=start_date)
     expected_completion_2 = NexusCompletion(date=start_date, i=6, j=7, k=8, well_radius=9.11, date_format=date_format,
-                                            unit_system=expected_units)
+                                            unit_system=expected_units, start_date=start_date)
 
     dummy_model = get_fake_nexus_simulator(mocker)
     dummy_wells = NexusWells(model=dummy_model)
@@ -758,7 +780,8 @@ DATEFORMAT     DD/MM/YYYY
     dummy_wells = NexusWells(model=dummy_model)
 
     expected_completion_1 = NexusCompletion(date=expected_date, i=1, j=2, k=3, skin=None, well_radius=4.5, angle_v=None,
-                                            grid=None, date_format=date_format, unit_system=UnitSystem.ENGLISH)
+                                            grid=None, date_format=date_format, unit_system=UnitSystem.ENGLISH,
+                                            start_date=start_date)
 
     # mock out open to return our test file contents
     open_mock = mocker.mock_open(read_data=wellspec_contents)
@@ -792,7 +815,8 @@ DATEFORMAT     MM/DD/YYYY
     dummy_wells = NexusWells(model=dummy_model)
 
     expected_completion_1 = NexusCompletion(date=expected_date, i=1, j=2, k=3, skin=None, well_radius=4.5, angle_v=None,
-                                            grid=None, date_format=date_format, unit_system=UnitSystem.ENGLISH)
+                                            grid=None, date_format=date_format, unit_system=UnitSystem.ENGLISH,
+                                            start_date=start_date)
 
     # mock out open to return our test file contents
     open_mock = mocker.mock_open(read_data=wellspec_contents)
@@ -826,7 +850,8 @@ DATEFORMAT     DD/MM/YYYY
     dummy_wells = NexusWells(model=dummy_model)
 
     expected_completion_1 = NexusCompletion(date=expected_date, i=1, j=2, k=3, skin=None, well_radius=4.5, angle_v=None,
-                                            grid=None, date_format=date_format, unit_system=UnitSystem.ENGLISH)
+                                            grid=None, date_format=date_format, unit_system=UnitSystem.ENGLISH,
+                                            start_date=start_date)
 
     # mock out open to return our test file contents
     open_mock = mocker.mock_open(read_data=wellspec_contents)
@@ -860,7 +885,8 @@ DATEFORMAT     MM/DD/YYYY
     dummy_wells = NexusWells(model=dummy_model)
 
     expected_completion_1 = NexusCompletion(date=expected_date, i=1, j=2, k=3, skin=None, well_radius=4.5, angle_v=None,
-                                            grid=None, date_format=date_format, unit_system=UnitSystem.ENGLISH)
+                                            grid=None, date_format=date_format, unit_system=UnitSystem.ENGLISH,
+                                            start_date=start_date)
 
     # mock out open to return our test file contents
     open_mock = mocker.mock_open(read_data=wellspec_contents)
@@ -893,7 +919,8 @@ def test_load_wells_plus_time_card_dd_mm_yyyy_decimal_with_time(mocker):
     dummy_wells = NexusWells(model=dummy_model)
 
     expected_completion_1 = NexusCompletion(date=expected_date, i=1, j=2, k=3, skin=None, well_radius=4.5, angle_v=None,
-                                            grid=None, date_format=date_format, unit_system=UnitSystem.ENGLISH)
+                                            grid=None, date_format=date_format, unit_system=UnitSystem.ENGLISH,
+                                            start_date=start_date)
 
     # mock out open to return our test file contents
     open_mock = mocker.mock_open(read_data=wellspec_contents)
@@ -926,7 +953,8 @@ def test_load_wells_plus_time_card_mm_dd_yyyy_decimal_with_time(mocker):
     dummy_wells = NexusWells(model=dummy_model)
 
     expected_completion_1 = NexusCompletion(date=expected_date, i=1, j=2, k=3, skin=None, well_radius=4.5, angle_v=None,
-                                            grid=None, date_format=date_format, unit_system=UnitSystem.ENGLISH)
+                                            grid=None, date_format=date_format, unit_system=UnitSystem.ENGLISH,
+                                            start_date=start_date)
 
     # mock out open to return our test file contents
     open_mock = mocker.mock_open(read_data=wellspec_contents)
@@ -959,7 +987,8 @@ def test_load_wells_plus_time_card_dd_mm_yyyy_decimal_with_time_ending_midnight(
     dummy_wells = NexusWells(model=dummy_model)
 
     expected_completion_1 = NexusCompletion(date=expected_date, i=1, j=2, k=3, skin=None, well_radius=4.5, angle_v=None,
-                                            grid=None, date_format=date_format, unit_system=UnitSystem.ENGLISH)
+                                            grid=None, date_format=date_format, unit_system=UnitSystem.ENGLISH,
+                                            start_date=start_date)
 
     # mock out open to return our test file contents
     open_mock = mocker.mock_open(read_data=wellspec_contents)
@@ -996,9 +1025,11 @@ def test_load_wells_plus_time_wellspec_card_mm_dd_yyyy_decimal_with_time(mocker)
     dummy_wells = NexusWells(model=dummy_model)
 
     expected_completion_1 = NexusCompletion(date=expected_date_1, i=1, j=2, k=3, skin=None, well_radius=4.5, angle_v=None,
-                                            grid=None, date_format=date_format, unit_system=UnitSystem.ENGLISH)
+                                            grid=None, date_format=date_format, unit_system=UnitSystem.ENGLISH,
+                                            start_date=start_date)
     expected_completion_2 = NexusCompletion(date=expected_date_2, i=6, j=5, k=4, skin=None, well_radius=7.77, angle_v=None,
-                                            grid=None, date_format=date_format, unit_system=UnitSystem.ENGLISH)
+                                            grid=None, date_format=date_format, unit_system=UnitSystem.ENGLISH,
+                                            start_date=start_date)
 
     # mock out open to return our test file contents
     open_mock = mocker.mock_open(read_data=wellspec_contents)
@@ -1017,6 +1048,7 @@ def test_load_wells_plus_time_wellspec_card_mm_dd_yyyy_decimal_with_time(mocker)
 
 def test_load_wells_start_date_issue(mocker):
     # Arrange
+    start_date = '30/04/1995'
     runcontrol_file = """START 30/04/1995
 
 METHOD IMPES
@@ -1046,21 +1078,21 @@ WELLS set 1 wells.dat"""
                                 completions=[NexusCompletion(date='30/04/1995', i=55, j=55, k=22, well_radius=0.354,
                                                              date_format=DateFormat.DD_MM_YYYY,
                                                              unit_system=UnitSystem.ENGLISH,
-                                                             start_date='30/04/1995'),
+                                                             start_date=start_date),
                                              NexusCompletion(date='30/04/1995', i=11, j=44, k=33, well_radius=0.354,
                                                              date_format=DateFormat.DD_MM_YYYY,
                                                              unit_system=UnitSystem.ENGLISH,
-                                                             start_date='30/04/1995')],
+                                                             start_date=start_date)],
                                 unit_system=UnitSystem.ENGLISH, parent_wells_instance=None)
     expected_result_2 = NexusWell(well_name='test_well_2',
                                   completions=[NexusCompletion(date='59.5', i=13, j=14, k=15, well_radius=0.354,
                                                                date_format=DateFormat.DD_MM_YYYY,
                                                                unit_system=UnitSystem.ENGLISH,
-                                                               start_date='30/04/1995'),
+                                                               start_date=start_date),
                                                NexusCompletion(date='59.5', i=16, j=17, k=18, well_radius=0.354,
                                                                date_format=DateFormat.DD_MM_YYYY,
                                                                unit_system=UnitSystem.ENGLISH,
-                                                               start_date='30/04/1995')],
+                                                               start_date=start_date)],
                                   unit_system=UnitSystem.ENGLISH, parent_wells_instance=None)
 
     # mock out above

--- a/tests/Nexus/test_nexus_well.py
+++ b/tests/Nexus/test_nexus_well.py
@@ -535,31 +535,36 @@ def test_find_completion(mocker, existing_completions):
 
 def test_add_completion(mocker):
     # Arrange
+    start_date = '01/01/2023'
     new_date = '01/04/2023'
     existing_completions = [
         NexusCompletion(date='01/01/2023', i=1, j=2, k=3, skin=None, well_radius=4.5, angle_v=None, grid='GRID1',
-                        well_indices=1, date_format=DateFormat.DD_MM_YYYY, unit_system=UnitSystem.METKGCM2),
+                        well_indices=1, date_format=DateFormat.DD_MM_YYYY, unit_system=UnitSystem.METKGCM2,
+                        start_date=start_date),
         NexusCompletion(date='01/02/2023', i=1, j=2, k=3, status='ON', partial_perf=1,
-                        date_format=DateFormat.DD_MM_YYYY, unit_system=UnitSystem.METKGCM2),
+                        date_format=DateFormat.DD_MM_YYYY, unit_system=UnitSystem.METKGCM2, start_date=start_date),
         NexusCompletion(date='01/02/2023', i=1, j=2, well_indices=0, depth_to_top=1156, depth_to_bottom=1234,
                         status='ON', partial_perf=1, date_format=DateFormat.DD_MM_YYYY,
-                        unit_system=UnitSystem.METKGCM2),
+                        unit_system=UnitSystem.METKGCM2, start_date=start_date),
         NexusCompletion(date='01/02/2023', i=1, j=2, k=5, well_indices=3, status='ON', partial_perf=1,
-                        date_format=DateFormat.DD_MM_YYYY, unit_system=UnitSystem.METKGCM2),
+                        date_format=DateFormat.DD_MM_YYYY, unit_system=UnitSystem.METKGCM2, start_date=start_date),
         NexusCompletion(date='01/03/2023', i=1, j=2, well_indices=0, depth_to_top=1156, depth_to_bottom=1234,
                         status='ON', partial_perf=1, date_format=DateFormat.DD_MM_YYYY,
-                        unit_system=UnitSystem.METKGCM2),
+                        unit_system=UnitSystem.METKGCM2, start_date=start_date),
     ]
     new_completion_props = {'i': 3, 'j': 3, 'k': 5, 'well_radius': 1005.2, 'date_format': DateFormat.DD_MM_YYYY}
 
     new_nexus_completion = NexusCompletion(date=new_date, i=3, j=3, k=5, well_radius=1005.2,
-                                           date_format=DateFormat.DD_MM_YYYY, unit_system=UnitSystem.METKGCM2)
+                                           date_format=DateFormat.DD_MM_YYYY, unit_system=UnitSystem.METKGCM2,
+                                           start_date=start_date)
 
     expected_completions = [x for x in existing_completions]
     expected_completions.append(new_nexus_completion)
 
     dummy_model = get_fake_nexus_simulator(mocker)
+    dummy_model.start_date = start_date
     dummy_wells = NexusWells(model=dummy_model)
+    dummy_wells.__setattr__('_NexusWells__date_format', DateFormat.DD_MM_YYYY)
 
     expected_well = NexusWell(well_name='test well', completions=expected_completions,
                               unit_system=UnitSystem.METKGCM2, parent_wells_instance=dummy_wells)
@@ -693,9 +698,10 @@ def test_wells_modify(mocker):
     DATEFORMAT DD/MM/YYYY
 
     RECURRENT_FILES
-    RUNCONTROL ref_runcontrol.dat
+    RUNCONTROL /ref_runcontrol.dat
     WELLS Set 1 /my/wellspec/file.dat'''
     runcontrol_data = 'START 01/01/2020'
+    start_date = '01/01/2020'
     wells_file = '''TIME 01/01/2020
     well
     TIME 01/01/2023
@@ -719,7 +725,7 @@ def test_wells_modify(mocker):
         mock_open = mock_multiple_files(mocker, filename, potential_file_dict={
             'fcs_file.fcs': fcs_file_data,
             '/my/wellspec/file.dat': wells_file,
-            'ref_runcontrol.dat': runcontrol_data,
+            '/ref_runcontrol.dat': runcontrol_data,
         }).return_value
         return mock_open
 
@@ -729,17 +735,20 @@ def test_wells_modify(mocker):
 
     well_1_completions = [
         NexusCompletion(date='01/01/2023', i=1, j=2, k=3, skin=None, well_radius=4.5, angle_v=None, grid='GRID1',
-                        well_indices=1, date_format=DateFormat.DD_MM_YYYY, unit_system=UnitSystem.ENGLISH),
+                        well_indices=1, date_format=DateFormat.DD_MM_YYYY, unit_system=UnitSystem.ENGLISH,
+                        start_date=start_date),
         NexusCompletion(date='01/02/2023', i=1, j=2, k=3, status='ON', partial_perf=1,
-                        date_format=DateFormat.DD_MM_YYYY, unit_system=UnitSystem.ENGLISH),
+                        date_format=DateFormat.DD_MM_YYYY, unit_system=UnitSystem.ENGLISH, start_date=start_date),
         NexusCompletion(date='01/02/2023', i=1, j=2, k=5, well_indices=0, depth_to_top=1156, depth_to_bottom=1234,
-                        status='ON', partial_perf=1, date_format=DateFormat.DD_MM_YYYY, unit_system=UnitSystem.ENGLISH)]
+                        status='ON', partial_perf=1, date_format=DateFormat.DD_MM_YYYY, unit_system=UnitSystem.ENGLISH,
+                        start_date=start_date)]
 
     well_2_completions = [
         NexusCompletion(date='01/02/2023', i=1, j=2, k=5, well_indices=3, status='ON', partial_perf=1,
-                        date_format=DateFormat.DD_MM_YYYY, unit_system=UnitSystem.ENGLISH),
+                        date_format=DateFormat.DD_MM_YYYY, unit_system=UnitSystem.ENGLISH, start_date=start_date),
         NexusCompletion(date='01/02/2023', i=1, j=2, well_indices=0, depth_to_top=1156, depth_to_bottom=1234,
-                        status='ON', partial_perf=1, date_format=DateFormat.DD_MM_YYYY, unit_system=UnitSystem.ENGLISH)]
+                        status='ON', partial_perf=1, date_format=DateFormat.DD_MM_YYYY, unit_system=UnitSystem.ENGLISH,
+                        start_date=start_date)]
 
     wells = nexus_sim.wells
 
@@ -751,16 +760,21 @@ def test_wells_modify(mocker):
                       'depth_to_bottom': 1234}
 
     new_nexus_completion_1 = NexusCompletion(date=date, i=3, j=3, k=5, well_radius=1005.2,
-                                             date_format=DateFormat.DD_MM_YYYY, unit_system=UnitSystem.ENGLISH)
+                                             date_format=DateFormat.DD_MM_YYYY, unit_system=UnitSystem.ENGLISH,
+                                             start_date=start_date)
     new_nexus_completion_2 = NexusCompletion(date=date, i=1, j=2, k=6, permeability=1005.2,
-                                             date_format=DateFormat.DD_MM_YYYY, unit_system=UnitSystem.ENGLISH)
+                                             date_format=DateFormat.DD_MM_YYYY, unit_system=UnitSystem.ENGLISH,
+                                             start_date=start_date)
     expected_completions = well_1_completions[0:2] + [new_nexus_completion_1, new_nexus_completion_2]
 
     dummy_model = get_fake_nexus_simulator(mocker)
+    dummy_model._start_date = start_date
     dummy_wells = NexusWells(model=dummy_model)
 
-    expected_result = [NexusWell(well_name='well1', completions=expected_completions, unit_system=UnitSystem.ENGLISH, parent_wells_instance=dummy_wells),
-                       NexusWell(well_name='well2', completions=well_2_completions, unit_system=UnitSystem.ENGLISH, parent_wells_instance=dummy_wells)]
+    expected_result = [NexusWell(well_name='well1', completions=expected_completions, unit_system=UnitSystem.ENGLISH,
+                                 parent_wells_instance=dummy_wells),
+                       NexusWell(well_name='well2', completions=well_2_completions, unit_system=UnitSystem.ENGLISH,
+                                 parent_wells_instance=dummy_wells)]
 
     # Act
     wells.modify(well_name='well1', completion_properties_list=[perf_1_to_add, perf_2_to_add],

--- a/tests/Nexus/test_nexus_wellmod.py
+++ b/tests/Nexus/test_nexus_wellmod.py
@@ -23,10 +23,9 @@ class TestNexusWellMod:
         7 6 8   9.11
         '''
     expected_completion_1 = NexusCompletion(date=start_date, i=1, j=2, k=3, well_radius=4.5,
-                                            date_format=date_format, unit_system=unit_system)
+                                            date_format=date_format, unit_system=unit_system, start_date=start_date)
     expected_completion_2 = NexusCompletion(date=start_date, i=6, j=7, k=8, well_radius=9.11,
-                                            date_format=date_format,
-                                            unit_system=unit_system)
+                                            date_format=date_format, unit_system=unit_system, start_date=start_date)
 
     @pytest.mark.parametrize('wellfile_content, expected_wellmod_dict', [
         # simple_wellmod
@@ -46,7 +45,9 @@ class TestNexusWellMod:
         expected_wellmods = [NexusWellMod(expected_wellmod_dict)]
 
         dummy_model = get_fake_nexus_simulator(mocker)
+        dummy_model.start_date = self.start_date
         dummy_wells = NexusWells(model=dummy_model)
+        dummy_wells.__setattr__('_NexusWells__date_format', DateFormat.DD_MM_YYYY)
 
         expected_wells = [NexusWell(well_name='test_well',
                                     completions=[self.expected_completion_1, self.expected_completion_2],
@@ -84,10 +85,11 @@ class TestNexusWellMod:
 
         expected_completion_test_well_2_1 = NexusCompletion(date=self.start_date, i=1, j=1, k=1, skin=None,
                                                             well_radius=4.5, date_format=self.date_format,
-                                                            unit_system=self.unit_system)
+                                                            unit_system=self.unit_system, start_date=self.start_date)
         expected_completion_test_well_2_2 = NexusCompletion(date=self.start_date, i=2, j=2, k=2,
                                                             skin=None, well_radius=5.5,
-                                                            date_format=self.date_format, unit_system=self.unit_system)
+                                                            date_format=self.date_format, unit_system=self.unit_system,
+                                                            start_date=self.start_date)
 
         dummy_model = get_fake_nexus_simulator(mocker)
         dummy_wells = NexusWells(model=dummy_model)
@@ -166,13 +168,17 @@ class TestNexusWellMod:
                                              'perm_thickness_mult': 1234.2, 'delta_krw': [1.1]})
 
         extra_expected_completion_1 = NexusCompletion(date='01/01/2021', i=1, j=1, k=1, well_radius=4.5,
-                                                      date_format=self.date_format, unit_system=self.unit_system)
+                                                      date_format=self.date_format, unit_system=self.unit_system,
+                                                      start_date=self.start_date)
         extra_expected_completion_2 = NexusCompletion(date='01/01/2021', i=1, j=1, k=2, well_radius=4.6,
-                                                      date_format=self.date_format, unit_system=self.unit_system)
+                                                      date_format=self.date_format, unit_system=self.unit_system,
+                                                      start_date=self.start_date)
         extra_expected_completion_3 = NexusCompletion(date='01/01/2021', i=1, j=1, k=3, well_radius=4.7,
-                                                        date_format=self.date_format, unit_system=self.unit_system)
+                                                        date_format=self.date_format, unit_system=self.unit_system,
+                                                      start_date=self.start_date)
         extra_expected_completion_4 = NexusCompletion(date='01/01/2023', i=1, j=1, k=1, well_radius=4.5,
-                                                      date_format=self.date_format, unit_system=self.unit_system)
+                                                      date_format=self.date_format, unit_system=self.unit_system,
+                                                      start_date=self.start_date)
 
         dummy_model = get_fake_nexus_simulator(mocker)
         dummy_wells = NexusWells(model=dummy_model)
@@ -186,7 +192,8 @@ class TestNexusWellMod:
                           NexusWell(well_name='test_well2',
                                     completions=[NexusCompletion(date='01/01/2022', i=2, j=2, k=3, skin=4,
                                                                  date_format=self.date_format,
-                                                                 unit_system=self.unit_system)],
+                                                                 unit_system=self.unit_system,
+                                                                 start_date=self.start_date)],
                                     wellmods=[NexusWellMod({'well_name': 'test_well2', 'date': '01/01/2023',
                                                             'unit_system': self.unit_system, 'skin': 2})],
                                     unit_system=self.unit_system, parent_wells_instance=dummy_wells)]

--- a/tests/utility_for_tests.py
+++ b/tests/utility_for_tests.py
@@ -45,6 +45,7 @@ def get_fake_nexus_simulator(mocker: MockerFixture, fcs_file_path: str = '/path/
 
     return fake_nexus_sim
 
+
 def uuid_side_effect():
     """Generates an infinite sequence of overwrites for uuid calls."""
     num = 0
@@ -54,7 +55,7 @@ def uuid_side_effect():
 
 
 def generic_fcs(mocker):
-
+    """Generates a set of fake FCS file contents."""
     fcs_path = 'test_fcs.fcs'
 
     fcs_content = '''DESC reservoir1


### PR DESCRIPTION
Pass through start date to completions
Prevent parent_wells from being compared on comparison of the NexusWells class and the same with the passed through model on comparison of the parent model on the wells class. 