### PR TITLE
stop default parent class overwriting to_dict

### DIFF
--- a/ResSimpy/Nexus/DataModels/NexusCompletion.py
+++ b/ResSimpy/Nexus/DataModels/NexusCompletion.py
@@ -288,10 +288,9 @@ class NexusCompletion(Completion):
     def to_dict(self, keys_in_keyword_style: bool = False, add_date=True, add_units=False, include_nones=True) -> \
             dict[str, None | str | int | float]:
 
-        # overwrite add_units to be False for completions as they currently do not contain units.
-        attribute_dict = to_dict(self, keys_in_keyword_style, add_date, add_units=False, include_nones=include_nones)
+        attribute_dict = to_dict(self, keys_in_keyword_style, add_date=add_date, add_units=add_units, include_nones=include_nones)
         parent_attribute_dict = super().to_dict(keys_in_keyword_style=keys_in_keyword_style, add_date=add_date,
-                                                add_units=False, include_nones=include_nones)
+                                                add_units=add_units, include_nones=include_nones)
 
         attribute_dict.update(parent_attribute_dict)
         if self.rel_perm_end_point is not None:

--- a/ResSimpy/Nexus/DataModels/NexusCompletion.py
+++ b/ResSimpy/Nexus/DataModels/NexusCompletion.py
@@ -288,7 +288,8 @@ class NexusCompletion(Completion):
     def to_dict(self, keys_in_keyword_style: bool = False, add_date=True, add_units=False, include_nones=True) -> \
             dict[str, None | str | int | float]:
 
-        attribute_dict = to_dict(self, keys_in_keyword_style, add_date=add_date, add_units=add_units, include_nones=include_nones)
+        attribute_dict = to_dict(self, keys_in_keyword_style, add_date=add_date,
+                                 add_units=add_units, include_nones=include_nones)
         parent_attribute_dict = super().to_dict(keys_in_keyword_style=keys_in_keyword_style, add_date=add_date,
                                                 add_units=add_units, include_nones=include_nones)
 

--- a/ResSimpy/Nexus/DataModels/NexusCompletion.py
+++ b/ResSimpy/Nexus/DataModels/NexusCompletion.py
@@ -289,9 +289,11 @@ class NexusCompletion(Completion):
             dict[str, None | str | int | float]:
 
         # overwrite add_units to be False for completions as they currently do not contain units.
-        attribute_dict = to_dict(self, keys_in_keyword_style, add_date, add_units=False,
-                                 include_nones=include_nones)
+        attribute_dict = to_dict(self, keys_in_keyword_style, add_date, add_units=False, include_nones=include_nones)
+        parent_attribute_dict = super().to_dict(keys_in_keyword_style=keys_in_keyword_style, add_date=add_date,
+                                                add_units=False, include_nones=include_nones)
 
+        attribute_dict.update(parent_attribute_dict)
         if self.rel_perm_end_point is not None:
             attribute_dict.update(self.rel_perm_end_point.to_dict())
         return attribute_dict

--- a/ResSimpy/Nexus/DataModels/NexusCompletion.py
+++ b/ResSimpy/Nexus/DataModels/NexusCompletion.py
@@ -289,10 +289,9 @@ class NexusCompletion(Completion):
             dict[str, None | str | int | float]:
 
         # overwrite add_units to be False for completions as they currently do not contain units.
-        attribute_dict = to_dict(self, keys_in_keyword_style, add_date, add_units=add_units,
+        attribute_dict = to_dict(self, keys_in_keyword_style, add_date, add_units=False,
                                  include_nones=include_nones)
 
-        attribute_dict.update(super().to_dict(add_units=False))
         if self.rel_perm_end_point is not None:
             attribute_dict.update(self.rel_perm_end_point.to_dict())
         return attribute_dict

--- a/tests/Nexus/nexus_simulator/test_nexus_to_dict.py
+++ b/tests/Nexus/nexus_simulator/test_nexus_to_dict.py
@@ -1,0 +1,15 @@
+from ResSimpy.Nexus.NexusEnums.DateFormatEnum import DateFormat
+from ResSimpy.Nexus.DataModels.NexusCompletion import NexusCompletion
+
+
+def test_nexus_completion_to_dict():
+    # Arrange
+    expected_completion = {'date': '01/02/2023', 'grid': 'GRID1', 'i': 1, 'j': 2, 'k': 3,
+                           'partial_perf': 0.1, 'well_radius': 4.5}
+    # Act
+    result = NexusCompletion(date='01/02/2023', i=1, j=2, k=3, skin=None, well_radius=4.5, angle_v=None,
+                             grid='GRID1', partial_perf=0.1,
+                             date_format=DateFormat.DD_MM_YYYY).to_dict(add_units=True, include_nones=False)
+
+    # Assert
+    assert result == expected_completion

--- a/tests/Nexus/nexus_simulator/test_nexus_to_dict.py
+++ b/tests/Nexus/nexus_simulator/test_nexus_to_dict.py
@@ -1,15 +1,77 @@
 from ResSimpy.Nexus.NexusEnums.DateFormatEnum import DateFormat
 from ResSimpy.Nexus.DataModels.NexusCompletion import NexusCompletion
+from ResSimpy.Enums.UnitsEnum import UnitSystem
+import pytest
 
 
-def test_nexus_completion_to_dict():
+@pytest.mark.parametrize("add_date, add_units, expected_result", [
+    (True, True, {'date': '01/02/2023', 'grid': 'GRID1', 'i': 1, 'j': 2, 'k': 3,
+                  'partial_perf': 0.1, 'well_radius': 4.5, 'unit_system': 'ENGLISH'}),
+    (True, False, {'date': '01/02/2023', 'grid': 'GRID1', 'i': 1, 'j': 2, 'k': 3,
+                   'partial_perf': 0.1, 'well_radius': 4.5}),
+    (False, False, {'grid': 'GRID1', 'i': 1, 'j': 2, 'k': 3,
+                    'partial_perf': 0.1, 'well_radius': 4.5})
+])
+def test_nexus_completion_to_dict(add_date, add_units, expected_result):
     # Arrange
-    expected_completion = {'date': '01/02/2023', 'grid': 'GRID1', 'i': 1, 'j': 2, 'k': 3,
-                           'partial_perf': 0.1, 'well_radius': 4.5}
+
     # Act
-    result = NexusCompletion(date='01/02/2023', i=1, j=2, k=3, skin=None, well_radius=4.5, angle_v=None,
-                             grid='GRID1', partial_perf=0.1,
-                             date_format=DateFormat.DD_MM_YYYY).to_dict(add_units=True, include_nones=False)
+    result = (NexusCompletion(date='01/02/2023', i=1, j=2, k=3, skin=None, well_radius=4.5, angle_v=None, grid='GRID1',
+                              partial_perf=0.1, date_format=DateFormat.DD_MM_YYYY, unit_system=UnitSystem.ENGLISH)
+              .to_dict(add_date=add_date, add_units=add_units, include_nones=False))
 
     # Assert
-    assert result == expected_completion
+    assert result == expected_result
+
+
+def test_nexus_completion_to_dict_include_nones():
+    expected_result = {'angle_a': None,
+                       'angle_open_flow': None,
+                       'angle_v': None,
+                       'cell_number': None,
+                       'comp_dz': None,
+                       'date': '01/02/2023',
+                       'depth': None,
+                       'depth_to_bottom': None,
+                       'depth_to_top': None,
+                       'dfactor': None,
+                       'flowsector': None,
+                       'fracture_mult': None,
+                       'grid': 'GRID1',
+                       'i': 1,
+                       'j': 2,
+                       'k': 3,
+                       'kh_mult': None,
+                       'layer_assignment': None,
+                       'length': None,
+                       'mdcon': None,
+                       'measured_depth': None,
+                       'non_darcy_model': None,
+                       'parent_node': None,
+                       'partial_perf': 0.1,
+                       'peaceman_well_block_radius': None,
+                       'perm_thickness_ovr': None,
+                       'permeability': None,
+                       'polymer_block_radius': None,
+                       'polymer_well_radius': None,
+                       'portype': None,
+                       'pressure_avg_pattern': None,
+                       'rel_perm_method': None,
+                       'sector': None,
+                       'skin': None,
+                       'status': None,
+                       'temperature': None,
+                       'unit_system': 'ENGLISH',
+                       'well_group': None,
+                       'well_indices': None,
+                       'well_radius': 4.5,
+                       'x': None,
+                       'y': None,
+                       'zone': None}
+
+    result = NexusCompletion(date='01/02/2023', i=1, j=2, k=3, skin=None, well_radius=4.5, angle_v=None,
+                             grid='GRID1', partial_perf=0.1, date_format=DateFormat.DD_MM_YYYY,
+                             unit_system=UnitSystem.ENGLISH).to_dict(add_date=True, add_units=True, include_nones=True)
+
+    # Assert
+    assert result == expected_result


### PR DESCRIPTION
Previously, to_dict arguments were overwritten by the default arguments of the parent class. 

I've removed the super() function.