### PR TITLE
Add region number to nexus target

### DIFF
--- a/ResSimpy/Nexus/DataModels/Network/NexusTargets.py
+++ b/ResSimpy/Nexus/DataModels/Network/NexusTargets.py
@@ -11,6 +11,7 @@ from typing import Sequence, Optional, TYPE_CHECKING
 import pandas as pd
 
 from ResSimpy.File import File
+from ResSimpy.Nexus.DataModels.NexusOptions import NexusOptions
 from ResSimpy.Nexus.nexus_add_new_object_to_file import AddObjectOperations
 from ResSimpy.Nexus.nexus_collect_tables import collect_all_tables_to_objects
 from ResSimpy.Nexus.DataModels.Network.NexusTarget import NexusTarget
@@ -161,3 +162,14 @@ class NexusTargets(Targets):
 
         self.__modify_object_operations.modify_network_object(target_to_modify, new_properties,
                                                               self.__parent_network)
+
+    def _look_up_region_numbers_for_targets(self, options_file: NexusOptions) -> None:
+        """Looks up the region numbers for the targets based on the region names in the options file.
+
+        Args:
+            options_file (NexusOptions): options file object
+
+        """
+        for target in self._targets:
+            if target.region is not None:
+                target.region_number = options_file.look_up_region_number_by_name(target.region)

--- a/ResSimpy/Nexus/DataModels/NexusOptions.py
+++ b/ResSimpy/Nexus/DataModels/NexusOptions.py
@@ -196,7 +196,7 @@ class NexusOptions(DynamicProperty):
         if reg_data is None or not isinstance(reg_data, dict):
             return -1
         for table in reg_data.values():
-            table['NAME'] = table['NAME'].str.upper()
-            if table['NAME'].isin([region_name]).sum() > 0:
-                return table[table['NAME'] == region_name]['NUMBER'].to_numpy()[0]
+            upper_names = table['NAME'].str.upper()
+            if upper_names.isin([region_name]).sum() > 0:
+                return table[upper_names == region_name]['NUMBER'].to_numpy()[0]
         return -1

--- a/ResSimpy/Nexus/DataModels/NexusOptions.py
+++ b/ResSimpy/Nexus/DataModels/NexusOptions.py
@@ -181,3 +181,22 @@ class NexusOptions(DynamicProperty):
             self.properties['REGDATA'] = reg_dfs
 
         self.__properties_loaded = True
+
+    def look_up_region_number_by_name(self, region_name: str) -> int:
+        """Look up the region number by the region name in the REGDATA.
+
+        Args:
+        region_name (str): Name of the region to look up.
+
+        Returns:
+        int: The region number if found, otherwise -1.
+        """
+        region_name = region_name.upper()
+        reg_data = self.properties.get('REGDATA', None)
+        if reg_data is None or not isinstance(reg_data, dict):
+            return -1
+        for table in reg_data.values():
+            table['NAME'] = table['NAME'].str.upper()
+            if table['NAME'].isin([region_name]).sum() > 0:
+                return table[table['NAME'] == region_name]['NUMBER'].to_numpy()[0]
+        return -1

--- a/ResSimpy/Nexus/NexusNetwork.py
+++ b/ResSimpy/Nexus/NexusNetwork.py
@@ -256,6 +256,9 @@ class NexusNetwork(Network):
 
         self.__has_been_loaded = True
         self.__update_well_types()
+        if self.model.options is not None:
+            # assign the region numbers for the targets with a region name
+            self.targets._look_up_region_numbers_for_targets(self.model.options)
 
     def __update_well_types(self) -> None:
         """Updates the types of all of the wells using information found in the wells table."""

--- a/ResSimpy/Target.py
+++ b/ResSimpy/Target.py
@@ -28,6 +28,7 @@ class Target(DataObjectMixin, ABC):
     rank_dt: Optional[float] = None
     control_type: Optional[str] = None
     calculation_type: Optional[str] = None
+    region_number: Optional[int] = None
 
     @property
     def units(self) -> NetworkUnits:

--- a/tests/Nexus/Properties/test_nexus_options.py
+++ b/tests/Nexus/Properties/test_nexus_options.py
@@ -176,9 +176,7 @@ ENDGLOBAL_METHOD_OVERRIDES
     ('Reg2', 2),
     ('Reg3', -1),
     ('GrApE', 22),
-    
-]
-                         )
+])
 def test_look_up_region_number_by_name(region_name, expected_output):
     # Arrange
     opts_file = NexusFile(location='test/file/options.dat')
@@ -197,9 +195,8 @@ def test_look_up_region_number_by_name(region_name, expected_output):
                                                               'NAME': ['Apple', 'Grape', 'Orange', 'Reg1']
                                                               })}
                            }
-    expected_output = 2
     # Act
-    result = opts_obj.look_up_region_number_by_name('Reg2')
+    result = opts_obj.look_up_region_number_by_name(region_name)
     
     # Assert
     assert result == expected_output

--- a/tests/Nexus/Properties/test_nexus_options.py
+++ b/tests/Nexus/Properties/test_nexus_options.py
@@ -169,3 +169,37 @@ ENDGLOBAL_METHOD_OVERRIDES
 
     # Assert
     assert result == expected_output
+
+
+@pytest.mark.parametrize("region_name, expected_output",[
+    ('Reg1', 1),
+    ('Reg2', 2),
+    ('Reg3', -1),
+    ('GrApE', 22),
+    
+]
+                         )
+def test_look_up_region_number_by_name(region_name, expected_output):
+    # Arrange
+    opts_file = NexusFile(location='test/file/options.dat')
+    opts_obj = NexusOptions(file=opts_file, model_unit_system=UnitSystem.ENGLISH)
+    opts_obj.properties = {'DESC': ['Simulation Options'],
+                           'UNIT_SYSTEM': UnitSystem.ENGLISH,
+                           'PSTD': 14.7,
+                           'TSTD': 60.0,
+                           'RES_TEMP': 200.0,
+                           'REGDATA': {
+                               'Injection_regions': pd.DataFrame({'NAME': ['Reg1', 'Reg2'],
+                                                                  'NUMBER': [1, 2],
+                                                                  'IBAT': [2, 2]
+                                                                  }),
+                               'Fruit_regions': pd.DataFrame({'NUMBER': [10, 22, 33, 44],
+                                                              'NAME': ['Apple', 'Grape', 'Orange', 'Reg1']
+                                                              })}
+                           }
+    expected_output = 2
+    # Act
+    result = opts_obj.look_up_region_number_by_name('Reg2')
+    
+    # Assert
+    assert result == expected_output

--- a/tests/Nexus/nexus_simulator/test_nexus_targets.py
+++ b/tests/Nexus/nexus_simulator/test_nexus_targets.py
@@ -1,8 +1,11 @@
+import pandas as pd
 import pytest
 from ResSimpy.Nexus.DataModels.Network import NexusTarget
 from ResSimpy.Nexus.DataModels.Network.NexusConstraint import NexusConstraint
 from ResSimpy.Nexus.DataModels.Network.NexusConstraints import NexusConstraints
 from ResSimpy.Enums.UnitsEnum import UnitSystem
+from ResSimpy.Nexus.DataModels.NexusFile import NexusFile
+from ResSimpy.Nexus.DataModels.NexusOptions import NexusOptions
 from ResSimpy.Nexus.NexusNetwork import NexusNetwork
 from tests.multifile_mocker import mock_multiple_files
 from tests.utility_for_tests import get_fake_nexus_simulator
@@ -29,8 +32,8 @@ from tests.utility_for_tests import get_fake_nexus_simulator
     target1   control1   ctrlcnd1   ctrlcons1   ctrlmthd1   calcmthd1   calccond1   calccons1   1.0   11.0   region1   1   1.5   1.8   Formula  1.6   0.9   type1   ctype1
     target2   control2   ctrlcnd2   ctrlcons2   ctrlmthd2   calcmthd2   calccond2   calccons2   2.0   21.0   region2   2   2.5   2.8   NA   2.6   1.9   type2   ctype2
     ENDTARGET'''
-    )
-    ],ids=['basic_test', 'guiderate with target column header'])
+     )
+], ids=['basic_test', 'guiderate with target column header'])
 def test_read_target(mocker, file_contents):
     # Arrange
     fcs_file_contents = '''
@@ -42,48 +45,107 @@ def test_read_target(mocker, file_contents):
         '''
     runcontrol_contents = '''START 01/01/2019'''
 
-  
+    def mock_open_wrapper(filename, mode):
+        mock_open = mock_multiple_files(mocker, filename, potential_file_dict={
+            '/path/fcs_file.fcs': fcs_file_contents,
+            '/surface_file_01.dat': file_contents,
+            '/nexus_data/runcontrol.dat': runcontrol_contents}
+                                        ).return_value
+        return mock_open
+
+    mocker.patch("builtins.open", mock_open_wrapper)
+    nexus_sim = get_fake_nexus_simulator(mocker, fcs_file_path='/path/fcs_file.fcs', mock_open=False)
+
+    target1_props = {'name': 'target1', 'control_quantity': 'control1', 'control_conditions': 'ctrlcnd1',
+                     'control_connections': 'ctrlcons1',
+                     'control_method': 'ctrlmthd1', 'calculation_method': 'calcmthd1',
+                     'calculation_conditions': 'calccond1', 'calculation_connections': 'calccons1',
+                     'value': 1.0, 'add_value': 11.0, 'region': 'region1', 'priority': 1,
+                     'minimum_rate': 1.5, 'minimum_rate_no_shut': 1.8, 'guide_rate': 'Formula',
+                     'max_change_pressure': 1.6,
+                     'rank_dt': 0.9, 'control_type': 'type1', 'calculation_type': 'ctype1',
+                     'unit_system': UnitSystem.ENGLISH}
+
+    target3_props = {'date': '01/01/2019', 'name': 'target3', 'control_quantity': 'control3',
+                     'control_conditions': 'ctrlcnd3', 'control_connections': 'ctrlcons3',
+                     'control_method': 'ctrlmthd3', 'calculation_method': 'calcmthd3',
+                     'calculation_conditions': 'calccond3', 'calculation_connections': 'calccons3',
+                     'value': 3.0, 'add_value': 31.0, 'region': 'region3', 'priority': 3,
+                     'minimum_rate': 3.5, 'minimum_rate_no_shut': 3.8, 'guide_rate': 'Formula',
+                     'max_change_pressure': 3.6,
+                     'rank_dt': 4.9, 'control_type': 'type3', 'calculation_type': 'ctype3',
+                     'unit_system': UnitSystem.ENGLISH}
+
+    # Act    
+    nexus_sim.network.load()
+
+    record_count = nexus_sim.network.targets.get_df()
+    target_record = nexus_sim.network.targets.get_by_name('target1')
+
+    target_dict = target_record.to_dict()
+    rec_to_remove = nexus_sim.network.targets.get_by_name('target2').to_dict()
+    nexus_sim.network.targets.remove({'name': rec_to_remove['name']})
+
+    nexus_sim.network.targets.add(target3_props)
+    targets_list_after_add = nexus_sim.network.targets.get_all()
+
+    # Assert
+    for k in target1_props:
+        assert target1_props[k] == target_dict[k]
+    assert record_count.shape[0] == 2
+    assert nexus_sim.network.targets.get_by_name('target2') == None
+    assert len(targets_list_after_add) == 2
+
+
+def test_add_region_numbers_to_targets(mocker):
+    # Arrange
+    fcs_file_contents = '''
+        RUN_UNITS ENGLISH
+        DATEFORMAT DD/MM/YYYY
+        RECURRENT_FILES
+        RUNCONTROL /nexus_data/runcontrol.dat
+        SURFACE Network 1  /surface_file_01.dat
+        '''
+    runcontrol_contents = '''START 01/01/2019'''
+    file_contents = '''TIME 01/01/2019
+        TARGET
+        NAME    CTRL   CTRLCOND   CTRLCONS   CTRLMETHOD   CALCMETHOD   CALCCOND   CALCCONS   VALUE   ADDVALUE   REGION   PRIORITY   QMIN   QMIN_NOSHUT   QGUIDE   MAXDPDT   RANKDT   CTRLTYPE   CALCTYPE
+        target1   control1   ctrlcnd1   ctrlcons1   ctrlmthd1   calcmthd1   calccond1   calccons1   1.0   11.0   region1   1   1.5   1.8   Formula  1.6   0.9   type1   ctype1
+        target2   control2   ctrlcnd2   ctrlcons2   ctrlmthd2   calcmthd2   calccond2   calccons2   2.0   21.0   region2   2   2.5   2.8   NA   2.6   1.9   type2   ctype2
+        ENDTARGET'''
 
     def mock_open_wrapper(filename, mode):
         mock_open = mock_multiple_files(mocker, filename, potential_file_dict={
             '/path/fcs_file.fcs': fcs_file_contents,
             '/surface_file_01.dat': file_contents,
             '/nexus_data/runcontrol.dat': runcontrol_contents}
-            ).return_value
+                                        ).return_value
         return mock_open
+
     mocker.patch("builtins.open", mock_open_wrapper)
     nexus_sim = get_fake_nexus_simulator(mocker, fcs_file_path='/path/fcs_file.fcs', mock_open=False)
-    
-     
-    target1_props={'name': 'target1', 'control_quantity': 'control1', 'control_conditions': 'ctrlcnd1', 'control_connections': 'ctrlcons1',
-      'control_method': 'ctrlmthd1', 'calculation_method': 'calcmthd1', 'calculation_conditions': 'calccond1', 'calculation_connections': 'calccons1',
-      'value': 1.0, 'add_value': 11.0, 'region': 'region1', 'priority': 1,
-      'minimum_rate': 1.5, 'minimum_rate_no_shut': 1.8, 'guide_rate': 'Formula', 'max_change_pressure': 1.6,
-      'rank_dt': 0.9, 'control_type': 'type1', 'calculation_type': 'ctype1','unit_system': UnitSystem.ENGLISH}
-    
-      
-    target3_props={'date':'01/01/2019','name': 'target3', 'control_quantity': 'control3', 'control_conditions': 'ctrlcnd3', 'control_connections': 'ctrlcons3',
-      'control_method': 'ctrlmthd3', 'calculation_method': 'calcmthd3', 'calculation_conditions': 'calccond3', 'calculation_connections': 'calccons3',
-      'value': 3.0, 'add_value': 31.0, 'region': 'region3', 'priority': 3,
-      'minimum_rate': 3.5, 'minimum_rate_no_shut': 3.8, 'guide_rate': 'Formula', 'max_change_pressure': 3.6,
-      'rank_dt': 4.9, 'control_type': 'type3', 'calculation_type': 'ctype3','unit_system': UnitSystem.ENGLISH}
 
-    # Act    
+    opts_file = NexusFile(location='test/file/options.dat')
+    opts_obj = NexusOptions(file=opts_file, model_unit_system=UnitSystem.ENGLISH)
+    opts_obj.properties = {'DESC': ['Simulation Options'],
+                           'UNIT_SYSTEM': UnitSystem.ENGLISH,
+                           'PSTD': 14.7,
+                           'TSTD': 60.0,
+                           'RES_TEMP': 200.0,
+                           'REGDATA': {
+                               'Injection_regions': pd.DataFrame({'NAME': ['region1', 'Reg2'],
+                                                                  'NUMBER': [1, 2],
+                                                                  'IBAT': [2, 2]
+                                                                  }),
+                               'Fruit_regions': pd.DataFrame({'NUMBER': [10, 22, 33, 44],
+                                                              'NAME': ['Apple', 'region2', 'Orange', 'Reg1']
+                                                              })}
+                           }
+    nexus_sim._options = opts_obj
+    
+    # Act
     nexus_sim.network.load()
     
-    record_count= nexus_sim.network.targets.get_df()
-    target_record=nexus_sim.network.targets.get_by_name('target1')
-    
-    target_dict=target_record.to_dict()
-    rec_to_remove=nexus_sim.network.targets.get_by_name('target2').to_dict()
-    nexus_sim.network.targets.remove({'name': rec_to_remove['name']})
-       
-    nexus_sim.network.targets.add(target3_props)
-    targets_list_after_add=nexus_sim.network.targets.get_all()
-    
     # Assert
-    for k in target1_props:
-        assert target1_props[k] == target_dict[k]  
-    assert record_count.shape[0] == 2
-    assert nexus_sim.network.targets.get_by_name('target2') == None
-    assert len(targets_list_after_add) == 2
+    assert nexus_sim.network.targets.get_by_name('target1').region_number == 1
+    assert nexus_sim.network.targets.get_by_name('target2').region_number == 22


### PR DESCRIPTION
Useful for conversions of targets for simulators that can't assign through string based regions.