### PR TITLE
Fix activate bug with new well connections in a subsequent timestep.

### DIFF
--- a/ResSimpy/Nexus/nexus_file_operations.py
+++ b/ResSimpy/Nexus/nexus_file_operations.py
@@ -486,8 +486,11 @@ def load_table_to_objects(file_as_list: list[str], row_object: Any, property_map
                 # If we are creating a Well Connection, carry across the activated state of the previous one.
                 if well_connections is not None and len(well_connections) > 0:
                     ordered_well_connections = sorted(well_connections, key=lambda x: x.iso_date, reverse=True)
-                    previous_well_connection = next(x for x in ordered_well_connections if x.name == name)
-                    is_activated = previous_well_connection.is_activated
+                    previous_well_connection = next((x for x in ordered_well_connections if x.name == name), None)
+                    if previous_well_connection is not None:
+                        is_activated = previous_well_connection.is_activated
+                    else:
+                        is_activated = True
                 else:
                     is_activated = True
 

--- a/tests/Nexus/nexus_simulator/test_nexus_network.py
+++ b/tests/Nexus/nexus_simulator/test_nexus_network.py
@@ -734,7 +734,10 @@ def test_wells_table_expands_out_wildcards(mocker: MockerFixture):
     ENDNODECON
     
     TIME 09/07/2024
-    
+        WELLS
+        NAME      STREAM      DATUM
+        well_dd  PRODUCER    1234
+    ENDWELLS
     WELLS
       NAME    ONTIME
       wel*_a* 0.85
@@ -792,7 +795,7 @@ def test_wells_table_expands_out_wildcards(mocker: MockerFixture):
     assert connections_for_c_june[0].datum_depth == 9123
 
     connections_on_9th_july = [x for x in result if x.date == '09/07/2024']
-    assert len(connections_on_9th_july) == 2
+    assert len(connections_on_9th_july) == 3
 
     connections_for_aa_july = [x for x in connections_on_9th_july if x.name == 'well_aa']
     assert connections_for_aa_july[0].on_time == 0.85
@@ -801,7 +804,7 @@ def test_wells_table_expands_out_wildcards(mocker: MockerFixture):
     assert connections_for_ab_july[0].on_time == 0.85
 
     connections_on_14th_july = [x for x in result if x.date == '14/07/2024']
-    assert len(connections_on_14th_july) == 3
+    assert len(connections_on_14th_july) == 4
 
     connections_for_aa_14th_july = [x for x in connections_on_14th_july if x.name == 'well_aa']
     assert connections_for_aa_14th_july[0].datum_depth == 4321


### PR DESCRIPTION
fixes bug with the activation carry over when a new well connection is defined with existing well connections from previous timesteps