### PR TITLE
Allows users to modify grid function

### DIFF
--- a/ResSimpy/DataModelBaseClasses/GridArrayDefinition.py
+++ b/ResSimpy/DataModelBaseClasses/GridArrayDefinition.py
@@ -129,3 +129,12 @@ class GridArrayDefinition:
     def id(self) -> UUID:
         """Unique identifier for each object."""
         return self.__id
+
+    def to_string(self, array: str) -> str:
+        """Converts the object to a string."""
+        grid_string = f'{array.upper()} {self.modifier}\n'
+        if self.modifier == 'VALUE':
+            grid_string += f'INCLUDE {self.value}\n'
+        else:
+            grid_string += f'{self.value}\n'
+        return grid_string

--- a/ResSimpy/DataModelBaseClasses/GridArrayDefinition.py
+++ b/ResSimpy/DataModelBaseClasses/GridArrayDefinition.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Optional
+from uuid import UUID, uuid4
 
 import numpy as np
 import pandas as pd
@@ -28,6 +29,28 @@ class GridArrayDefinition:
     keyword_in_include_file: bool = False
     absolute_path: Optional[str] = None
     array: Optional[np.ndarray] = None
+    __id: UUID = field(default_factory=lambda: uuid4(), compare=False)
+
+    def __init__(self, modifier: Optional[str] = None, value: Optional[str] = None,
+                 mods: Optional[dict[str, pd.DataFrame]] = None, keyword_in_include_file: bool = False,
+                 absolute_path: Optional[str] = None, array: Optional[np.ndarray] = None) -> None:
+        """Initializes a grid array definition object, representing a grid array property.
+
+        Args:
+            modifier (Optional[str]): the modifier for the grid array property (e.g. CON, MULT, etc.)
+            value (Optional[str]): the actual values for the grid array property in question. Can be an include file.
+            mods (Optional[dict[str, pd.DataFrame]): if the grid array has an associated mod card we capture it.
+            keyword_in_include_file (bool): an indicator to tell you if the grid array keyword was found in an inc file
+            absolute_path (Optional[str]): the absolute path to the path if value is an include file.
+            array (Optional[np.ndarray]): The loaded array from the grid file. Loads from the absolute path.
+        """
+        self.__id = uuid4()
+        self.modifier = modifier
+        self.value = value
+        self.mods = mods
+        self.keyword_in_include_file = keyword_in_include_file
+        self.absolute_path = absolute_path
+        self.array = array
 
     def load_grid_array_definition_to_file_as_list(self) -> list[str]:
         """Loads the grid array definition to a file as a list of strings."""
@@ -101,3 +124,8 @@ class GridArrayDefinition:
     def get_array(self) -> np.ndarray:
         """Returns the array from the grid array definition."""
         return self.get_array_from_file()
+
+    @property
+    def id(self) -> UUID:
+        """Unique identifier for each object."""
+        return self.__id

--- a/ResSimpy/FileOperations/file_operations.py
+++ b/ResSimpy/FileOperations/file_operations.py
@@ -395,6 +395,25 @@ def get_expected_token_value(token: str, token_line: str, file_list: list[str],
     return value
 
 
+def get_token_value_with_line_index(token: str, token_line: str, file_list: list[str],
+                                    ignore_values: Optional[list[str]] = None,
+                                    replace_with: Union[str, GridArrayDefinition, None] = None) -> tuple[str, int]:
+    """Gets the value following a token and the line index of that value.
+
+    Args:
+        token (str): the token being searched for.
+        token_line (str): string value of the line that the token was found in.
+        file_list (list[str]): a list of strings containing each line of the file as a new entry
+        ignore_values (list[str], optional): a list of values that should be ignored if found. \
+            Defaults to None.
+        replace_with (Union[str, VariableEntry, None], optional):  a value to replace the existing value with. \
+            Defaults to None.
+
+    Returns:
+        tuple[str, int]: The value following the supplied token and the line index of that value.
+    """
+
+
 def load_in_three_part_date(initial_token: str, token_line: str, file_as_list: list[str], start_index: int) -> str:
     """Function that reads in a three part date separated by spaces e.g. 1 JAN 2024.
 

--- a/ResSimpy/FileOperations/file_operations.py
+++ b/ResSimpy/FileOperations/file_operations.py
@@ -338,13 +338,23 @@ def get_token_value(token: str, token_line: str, file_list: list[str],
     Returns:
         Optional[str]: The value following the supplied token, if it is present.
     """
+    search_string, line_index = __extract_search_string(token, token_line, file_list)
+    if search_string is None or line_index is None:
+        return None
+    value = get_next_value(line_index, file_list, search_string, ignore_values, replace_with)
+    return value
 
+
+def __extract_search_string(token: str, token_line: str, file_list: list[str]) -> tuple[str | None, int | None]:
+    """Extracts the search string from the token line and returns the line index.
+    The line index is index of the token line.
+    """
     token_upper = token.upper()
     token_line_upper = token_line.upper()
 
     # If this line is commented out, don't return a value
     if "!" in token_line_upper and token_line_upper.index("!") < token_line_upper.index(token_upper):
-        return None
+        return None, None
 
     search_start = token_line_upper.index(token_upper) + len(token) + 1
     search_string = token_line[search_start: len(token_line)]
@@ -354,12 +364,11 @@ def get_token_value(token: str, token_line: str, file_list: list[str],
     if len(search_string) < 1:
         line_index += 1
         if line_index >= len(file_list):
-            return None
+            return None, None
         search_string = file_list[line_index]
     if not isinstance(search_string, str):
         raise ValueError
-    value = get_next_value(line_index, file_list, search_string, ignore_values, replace_with)
-    return value
+    return search_string, line_index
 
 
 def get_expected_token_value(token: str, token_line: str, file_list: list[str],
@@ -397,7 +406,8 @@ def get_expected_token_value(token: str, token_line: str, file_list: list[str],
 
 def get_token_value_with_line_index(token: str, token_line: str, file_list: list[str],
                                     ignore_values: Optional[list[str]] = None,
-                                    replace_with: Union[str, GridArrayDefinition, None] = None) -> tuple[str, int]:
+                                    replace_with: Union[str, GridArrayDefinition, None] = None) \
+        -> tuple[None | str, None | int]:
     """Gets the value following a token and the line index of that value.
 
     Args:
@@ -410,8 +420,19 @@ def get_token_value_with_line_index(token: str, token_line: str, file_list: list
             Defaults to None.
 
     Returns:
-        tuple[str, int]: The value following the supplied token and the line index of that value.
+        tuple[None | str, None | int]: The value following the supplied token and the line index of that value.
+            If None then no value was found.
     """
+    search_string, line_index = __extract_search_string(token, token_line, file_list)
+    if search_string is None or line_index is None:
+        return None, None
+    for i, line in enumerate(file_list[line_index:]):
+        if i != 0:
+            search_string = line
+        value = get_next_value(0, [line], search_string, ignore_values, replace_with)
+        if value is not None:
+            return value, line_index + i
+    return None, None
 
 
 def load_in_three_part_date(initial_token: str, token_line: str, file_as_list: list[str], start_index: int) -> str:

--- a/ResSimpy/Nexus/DataModels/NexusFile.py
+++ b/ResSimpy/Nexus/DataModels/NexusFile.py
@@ -733,6 +733,8 @@ class NexusFile(File):
             string_to_remove (Optional[str]): aligning call signature with remove_from_file_as_list - \
             not used in this method.
         """
+        # disable the string_to_remove argument as it is not used in this method
+        _ = string_to_remove
         nexusfile_to_write_to = self
 
         # remove the line in the file:

--- a/ResSimpy/Nexus/DataModels/NexusFile.py
+++ b/ResSimpy/Nexus/DataModels/NexusFile.py
@@ -605,12 +605,12 @@ class NexusFile(File):
         nexus_file = None
         for file in self.include_objects:
             if file.id == uuid_index:
-                nexus_file = file
+                nexus_file = file if not file.file_loading_skipped else self
             elif file.include_objects is not None:
                 # CURRENTLY THIS ONLY SUPPORTS 2 LEVELS OF INCLUDES
                 for lvl_2_include in file.include_objects:
                     if lvl_2_include.id == uuid_index:
-                        nexus_file = lvl_2_include
+                        nexus_file = lvl_2_include if not lvl_2_include.file_loading_skipped else file
         if nexus_file is None:
             raise ValueError(f'No file with {uuid_index=} found within include objects')
 
@@ -650,8 +650,14 @@ class NexusFile(File):
         for object_id, line_index in additional_objects.items():
             self.add_object_locations(obj_uuid=object_id, line_indices=line_index)
 
-    def remove_object_from_file_as_list(self, objects_to_remove: list[UUID]) -> None:
-        """Removes all associated lines in the file as well as the object locations relating to a list of objects."""
+    def remove_object_from_file_as_list(self, objects_to_remove: list[UUID], with_includes: bool = False) -> None:
+        """Removes all associated lines in the file as well as the object locations relating to a list of objects.
+
+        Args:
+            objects_to_remove (list[UUID]): list of object id's to remove from the object locations.
+            with_includes (bool): if set to True, the method will set the index relative to a file with includes.
+            Defaults to False.
+        """
         if self.object_locations is None:
             raise ValueError('Cannot remove object from object_locations as object_locations is None. '
                              'Check object locations is being populated properly.')
@@ -662,13 +668,17 @@ class NexusFile(File):
                 continue
             # sort from highest to lowest to ensure line indices are not affected by removal of lines
             sorted_obj_locs = sorted(obj_locs, reverse=True)
+
+            remove_func = self.remove_from_file_as_list if not with_includes else (
+                self.remove_from_file_as_list_with_includes)
+
             for i, index in enumerate(sorted_obj_locs):
                 if i == 0:
                     # for the first removal remove the object location
-                    self.remove_from_file_as_list(index, objects_to_remove=[obj_to_remove])
+                    remove_func(index, objects_to_remove=[obj_to_remove])
                 else:
                     # the remaining iterations remove just the lines
-                    self.remove_from_file_as_list(index)
+                    remove_func(index)
         self._file_modified_set(True)
 
     def remove_from_file_as_list(self, index: int, objects_to_remove: Optional[list[UUID]] = None,
@@ -704,6 +714,34 @@ class NexusFile(File):
                 raise ValueError(
                     f'Tried to replace at non string value at index: {relative_index} in '
                     f'file_as_list instead got {entry_to_replace}')
+
+        if objects_to_remove is not None:
+            for object_id in objects_to_remove:
+                self.__remove_object_locations(object_id)
+        self._file_modified_set(True)
+
+    def remove_from_file_as_list_with_includes(self, index: int, objects_to_remove: Optional[list[UUID]] = None,
+                                               string_to_remove: Optional[str] = None) -> None:
+        """Remove an entry from the file as list relative to file_as_list_with_includes.
+
+        Also updates existing object locations and removes any specified objects from the object locations dictionary.
+
+        Args:
+            index (int): index n the calling flat_file_as_list to remove the entry from
+            objects_to_remove (Optional[list[UUID]]): list of object id's to remove from the object locations. \
+            Defaults to None.
+            string_to_remove (Optional[str]): aligning call signature with remove_from_file_as_list - \
+            not used in this method.
+        """
+        nexusfile_to_write_to = self
+
+        # remove the line in the file:
+        if nexusfile_to_write_to.file_content_as_list is None:
+            raise ValueError(
+                f'No file content in the file attempting to remove line from {nexusfile_to_write_to.location}')
+
+        nexusfile_to_write_to.file_content_as_list.pop(index)
+        self.__update_object_locations(line_number=index, number_additional_lines=-1)
 
         if objects_to_remove is not None:
             for object_id in objects_to_remove:

--- a/ResSimpy/Nexus/DataModels/StructuredGrid/NexusGrid.py
+++ b/ResSimpy/Nexus/DataModels/StructuredGrid/NexusGrid.py
@@ -1658,3 +1658,21 @@ class NexusGrid(Grid):
         if not self._grid_properties_loaded:
             self.load_grid_properties_if_not_loaded()
         return self.__ftrans
+
+    def modify(self, array: str, new_properties: GridArrayDefinition) -> None:
+        """Modifies the properties of a grid array in the grid file.
+
+        Args:
+            array (str): the name of the grid array to modify.
+            new_properties (GridArrayDefinition): the new properties to set for the grid array.
+        """
+        if array not in self.__dict__:
+            raise ValueError(f'Array {array} not found in grid file')
+        # get the existing grid array definition
+        old_properties = getattr(self, array)
+
+        # update the properties in the object
+        setattr(self, array, new_properties)
+
+        # update the properties in the grid file
+

--- a/ResSimpy/Nexus/DataModels/StructuredGrid/NexusGrid.py
+++ b/ResSimpy/Nexus/DataModels/StructuredGrid/NexusGrid.py
@@ -563,7 +563,8 @@ class NexusGrid(Grid):
                         StructuredGridOperations.load_token_value_if_present(
                             token_property.token, modifier, token_property.property, line, file_as_list, idx,
                             grid_nexus_file=self.__grid_nexus_file, ignore_values=['INCLUDE', 'NOLIST'],
-                            original_line_location=original_line_location)
+                            original_line_location=original_line_location,
+                            file_as_list_with_original_line_numbers=file_as_list_with_original_line_numbers)
                     else:
                         # get the LGR object to add the grid array to:
                         lgr = self.lgrs.get(array_name)
@@ -572,7 +573,8 @@ class NexusGrid(Grid):
                         StructuredGridOperations.load_token_value_if_present(
                             token_property.token, modifier, grid_array_def_to_modify, line, file_as_list, idx,
                             grid_nexus_file=self.__grid_nexus_file, ignore_values=['INCLUDE', 'NOLIST'],
-                            original_line_location=original_line_location)
+                            original_line_location=original_line_location,
+                            file_as_list_with_original_line_numbers=file_as_list_with_original_line_numbers)
 
             # Load in grid dimensions
             if nfo.check_token('NX', line):

--- a/ResSimpy/Nexus/structured_grid_operations.py
+++ b/ResSimpy/Nexus/structured_grid_operations.py
@@ -280,7 +280,7 @@ class StructuredGridOperations:
     @staticmethod
     def append_include_to_grid_file(include_file_location: str, structured_grid_file_path: str) -> None:
         # TODO: change append to be an optional parameter
-        """Appe7nds an include file to the end of a grid for adding LGRs.
+        """Appends an include file to the end of a grid for adding LGRs.
 
         Args:
         ----

--- a/ResSimpy/Nexus/structured_grid_operations.py
+++ b/ResSimpy/Nexus/structured_grid_operations.py
@@ -31,8 +31,8 @@ class StructuredGridOperations:
                                     line: str, file_as_list: list[str], line_indx: int,
                                     grid_nexus_file: NexusFile,
                                     original_line_location: int,
+                                    file_as_list_with_original_line_numbers: list[tuple[int, str]],
                                     ignore_values: Optional[list[str]] = None,
-                                    file_as_list_with_original_line_numbers: Optional[list[tuple[int, str]]] = None
                                     ) -> None:
         """Gets a token's value if there is one and loads it into the token_property.
 
@@ -48,6 +48,8 @@ class StructuredGridOperations:
             grid_nexus_file (NexusFile): the NexusFile object containing the grid file.
             original_line_location (int): the line location relative to the expanded file as list with the include
             file paths.
+            file_as_list_with_original_line_numbers (list[tuple[int, str]]): a list of tuples containing the line
+            number from the expanded file_as_list and the line itself.
             ignore_values (Optional[list[str]]): values to be ignored. Defaults to None.
 
         Raises:
@@ -108,7 +110,6 @@ class StructuredGridOperations:
                                  for x in relative_line_locations]
             grid_nexus_file.add_object_locations(grid_array_definition.id, file_line_indices)
 
-
     @staticmethod
     def __make_grid_def(file_as_list: list[str], ignore_values: list[str], line: str, line_indx: int, modifier: str,
                         region_name: str, token_modifier: str,
@@ -125,12 +126,15 @@ class StructuredGridOperations:
         if modifier == 'MULT':
             numerical_value, line_loc = fo.get_token_value_with_line_index(
                 modifier, line, file_as_list[line_indx:], ignore_values=ignore_values)
-            if numerical_value is None:
+            if numerical_value is None or line_loc is None:
                 raise ValueError(
                     f'No numerical value found after {token_modifier} keyword in line: {line}')
             object_line_locs_relative_to_file_as_list.append(line_indx + line_loc)
             value_to_multiply, line_loc = fo.get_token_value_with_line_index(
                 modifier, line, file_as_list[line_indx:], ignore_values=[numerical_value, *ignore_values])
+            if value_to_multiply is None or line_loc is None:
+                raise ValueError(
+                    f'No value found to multiply after {numerical_value} in line: {line}')
             object_line_locs_relative_to_file_as_list.append(line_indx + line_loc)
             if numerical_value is not None and value_to_multiply is not None:
                 if not isinstance(token_property, dict):

--- a/ResSimpy/Nexus/structured_grid_operations.py
+++ b/ResSimpy/Nexus/structured_grid_operations.py
@@ -92,6 +92,9 @@ class StructuredGridOperations:
                                                      original_line_location=original_line_location)
             grid_array_definition = token_property if not isinstance(token_property, dict) else (
                 token_property)[region_name]
+            grid_id = grid_array_definition.id
+            grid_nexus_file.add_object_locations(grid_id, [original_line_location])
+
             mod_start_end = StructuredGridOperations.__extract_mod_positions(line_indx, file_as_list)
             if 'VMOD' in mod_start_end:
                 vmod_indices = mod_start_end.pop('VMOD')
@@ -106,6 +109,8 @@ class StructuredGridOperations:
                         token_property: GridArrayDefinition | dict[str, GridArrayDefinition],
                         grid_file: NexusFile, original_line_location: int) -> None:
         """A function that begins the process of populating the grid away."""
+
+        object_line_locs_relative_to_file_as_list = []
 
         if modifier == 'MULT':
             numerical_value = nfo.get_expected_token_value(modifier, line, file_as_list[line_indx:],

--- a/ResSimpy/Nexus/structured_grid_operations.py
+++ b/ResSimpy/Nexus/structured_grid_operations.py
@@ -32,6 +32,7 @@ class StructuredGridOperations:
                                     grid_nexus_file: NexusFile,
                                     original_line_location: int,
                                     ignore_values: Optional[list[str]] = None,
+                                    file_as_list_with_original_line_numbers: Optional[list[tuple[int, str]]] = None
                                     ) -> None:
         """Gets a token's value if there is one and loads it into the token_property.
 
@@ -79,7 +80,7 @@ class StructuredGridOperations:
             token_modifier = f"{token} {region_name} {modifier}"
         if token == 'IREGION' and isinstance(token_property, dict):
             if region_name == '':
-                region_name = f"IREG{len(token_property.keys())+1}"
+                region_name = f"IREG{len(token_property.keys()) + 1}"
 
         if token_found and modifier_found:
             # If we are loading a multiple, load the two relevant values, otherwise just the next value
@@ -87,13 +88,13 @@ class StructuredGridOperations:
             # piece one: make the grid definition array
             # piece two: find out if we have any MOD cards to deal with
             # piece three: make the mod table and add it to the grid array
-            StructuredGridOperations.__make_grid_def(file_as_list, ignore_values, line, line_indx, modifier,
-                                                     region_name, token_modifier, token_property, grid_nexus_file,
-                                                     original_line_location=original_line_location)
+            relative_line_locations = (
+                StructuredGridOperations.__make_grid_def(file_as_list, ignore_values, line, line_indx, modifier,
+                                                         region_name, token_modifier, token_property, grid_nexus_file,
+                                                         original_line_location=original_line_location))
             grid_array_definition = token_property if not isinstance(token_property, dict) else (
                 token_property)[region_name]
-            grid_id = grid_array_definition.id
-            grid_nexus_file.add_object_locations(grid_id, [original_line_location])
+            relative_line_locations.insert(0, line_indx)
 
             mod_start_end = StructuredGridOperations.__extract_mod_positions(line_indx, file_as_list)
             if 'VMOD' in mod_start_end:
@@ -102,24 +103,35 @@ class StructuredGridOperations:
                                                            grid_nexus_file)
             StructuredGridOperations.__make_mod_table(mod_start_end, file_as_list,
                                                       line, grid_array_definition, token_modifier)
+            # update the indices of the loaded gridarraydefinition
+            file_line_indices = [file_as_list_with_original_line_numbers[x][0]
+                                 for x in relative_line_locations]
+            grid_nexus_file.add_object_locations(grid_array_definition.id, file_line_indices)
+
 
     @staticmethod
     def __make_grid_def(file_as_list: list[str], ignore_values: list[str], line: str, line_indx: int, modifier: str,
                         region_name: str, token_modifier: str,
                         token_property: GridArrayDefinition | dict[str, GridArrayDefinition],
-                        grid_file: NexusFile, original_line_location: int) -> None:
-        """A function that begins the process of populating the grid away."""
+                        grid_file: NexusFile, original_line_location: int) -> list[int]:
+        """A function that begins the process of populating the grid away.
+
+        Returns:
+            list[int]: a list of line locations relative to the file as list.
+        """
 
         object_line_locs_relative_to_file_as_list = []
 
         if modifier == 'MULT':
-            numerical_value = nfo.get_expected_token_value(modifier, line, file_as_list[line_indx:],
-                                                           ignore_values=ignore_values)
+            numerical_value, line_loc = fo.get_token_value_with_line_index(
+                modifier, line, file_as_list[line_indx:], ignore_values=ignore_values)
             if numerical_value is None:
                 raise ValueError(
                     f'No numerical value found after {token_modifier} keyword in line: {line}')
-            value_to_multiply = fo.get_token_value(modifier, line, file_as_list[line_indx:],
-                                                   ignore_values=[numerical_value, *ignore_values])
+            object_line_locs_relative_to_file_as_list.append(line_indx + line_loc)
+            value_to_multiply, line_loc = fo.get_token_value_with_line_index(
+                modifier, line, file_as_list[line_indx:], ignore_values=[numerical_value, *ignore_values])
+            object_line_locs_relative_to_file_as_list.append(line_indx + line_loc)
             if numerical_value is not None and value_to_multiply is not None:
                 if not isinstance(token_property, dict):
                     token_property.modifier = 'MULT'
@@ -138,7 +150,8 @@ class StructuredGridOperations:
                 token_property[region_name].value = None
 
         else:
-            value = fo.get_token_value(modifier, line, file_as_list[line_indx:], ignore_values=ignore_values)
+            value, line_loc = fo.get_token_value_with_line_index(modifier, line, file_as_list[line_indx:],
+                                                                 ignore_values=ignore_values)
             if value is None:
                 # Could be 'cut short' by us excluding the rest of a file.
                 if not isinstance(token_property, dict):
@@ -152,7 +165,7 @@ class StructuredGridOperations:
                 # Check if VALUE modifier is followed by a numeric string or an INCLUDE file
                 line_to_check = file_as_list[line_indx + 1]
                 # Check next couple of lines in case next line contains one of ignore_values
-                for i in range(line_indx+1, min(line_indx+3, len(file_as_list))):
+                for i in range(line_indx + 1, min(line_indx + 3, len(file_as_list))):
                     if value in file_as_list[i]:
                         line_to_check = file_as_list[i]
                 if fo.check_token('INCLUDE', line_to_check):
@@ -162,6 +175,8 @@ class StructuredGridOperations:
                         StructuredGridOperations.__add_absolute_path_to_grid_array_definition(
                             grid_array_definition=token_property, line_index_of_include_file=original_line_location,
                             grid_nexus_file=grid_file)
+                        object_line_locs_relative_to_file_as_list.append(file_as_list.index(line_to_check))
+
                     elif region_name != '':  # IREGION
                         region_grid_def = GridArrayDefinition()
                         region_grid_def.modifier = modifier
@@ -172,6 +187,7 @@ class StructuredGridOperations:
                             grid_nexus_file=grid_file)
                         # store it in the dictionary of region grid definitions
                         token_property[region_name] = region_grid_def
+                        object_line_locs_relative_to_file_as_list.append(file_as_list.index(line_to_check))
 
                 elif check_if_string_is_float(value[0]) or value[0] == '.':
                     start_indx = line_indx + 1
@@ -189,13 +205,16 @@ class StructuredGridOperations:
                         token_property.modifier = modifier
                         token_property.value = '\n'.join([line.strip()
                                                           for line in file_as_list[start_indx:end_indx]]).strip()
+                        object_line_locs_relative_to_file_as_list.extend(list(range(start_indx, end_indx)))
                     elif region_name != '':  # IREGION
                         token_property[region_name] = GridArrayDefinition()
                         token_property[region_name].modifier = modifier
                         token_property[region_name].value = '\n'.join([line.strip() for line in
                                                                        file_as_list[start_indx:end_indx]]).strip()
+                        object_line_locs_relative_to_file_as_list.extend(list(range(start_indx, end_indx)))
                 else:  # The grid array keyword is likely inside an include file, presented on previous line
                     if fo.check_token('INCLUDE', file_as_list[line_indx - 1]):
+                        object_line_locs_relative_to_file_as_list.append(line_indx - 1)
                         if not isinstance(token_property, dict):
                             token_property.modifier = modifier
                             token_property.value = file_as_list[line_indx - 1].split('INCLUDE')[1].strip()
@@ -218,6 +237,7 @@ class StructuredGridOperations:
                     else:
                         raise ValueError(
                             f'No suitable value found after {token_modifier} keyword in line: {line}')
+        return object_line_locs_relative_to_file_as_list
 
     @staticmethod
     def replace_value(file_as_list: list[str], old_property: GridArrayDefinition, new_property: GridArrayDefinition,
@@ -256,7 +276,7 @@ class StructuredGridOperations:
     @staticmethod
     def append_include_to_grid_file(include_file_location: str, structured_grid_file_path: str) -> None:
         # TODO: change append to be an optional parameter
-        """Appends an include file to the end of a grid for adding LGRs.
+        """Appe7nds an include file to the end of a grid for adding LGRs.
 
         Args:
         ----
@@ -383,7 +403,7 @@ class StructuredGridOperations:
                 if mod_start_end.get('VMOD', None) is None:
                     mod_start_end['VMOD'] = []
                 mod_start_end['VMOD'].append([i + 1, i + 3])
-                for j, vmod_line in enumerate(file_as_list[i+1::], start=i + 1):
+                for j, vmod_line in enumerate(file_as_list[i + 1::], start=i + 1):
                     # find the include file
                     if nfo.check_token('INCLUDE', vmod_line):
                         mod_start_end['VMOD'][-1][1] = j
@@ -404,7 +424,7 @@ class StructuredGridOperations:
                     if nfo.check_token('NOSKIP', line_find_end):
                         skip_lines = False
                         # restart reading mods
-                        mod_start_end['MOD'].append([j+1, len(file_as_list)])
+                        mod_start_end['MOD'].append([j + 1, len(file_as_list)])
                     if skip_lines:
                         continue
                     for keyword in keywords_to_stop_on:
@@ -522,7 +542,7 @@ class StructuredGridOperations:
         absolute_path_root = os.path.dirname(grid_nexus_file.location)
 
         for (start_block, end_block) in vmod_indices:
-            file_section = file_as_list[start_block:end_block+1]
+            file_section = file_as_list[start_block:end_block + 1]
             for line in file_section:
                 split_line = nfo.split_line(line, upper=False)
                 if len(split_line) == 7:

--- a/tests/Nexus/test_modify_nexus_grid.py
+++ b/tests/Nexus/test_modify_nexus_grid.py
@@ -1,8 +1,6 @@
 import os
 import uuid
-
 import pytest
-
 from ResSimpy.DataModelBaseClasses.GridArrayDefinition import GridArrayDefinition
 from ResSimpy.Enums.UnitsEnum import UnitSystem
 from ResSimpy.Nexus.DataModels.NexusFile import NexusFile
@@ -10,9 +8,9 @@ from ResSimpy.Nexus.DataModels.StructuredGrid.NexusGrid import NexusGrid
 from multifile_mocker import mock_multiple_files
 from utility_for_tests import uuid_side_effect
 
-
-def test_load_grid_with_ids(mocker):
-    grid_text = """! Grid dimensions
+class TestModifyNexusGrid:
+    def setup_method(self, mocker):
+        self.grid_text = """! Grid dimensions
         NX NY NZ
         1 2 3
         test string
@@ -22,130 +20,153 @@ def test_load_grid_with_ids(mocker):
 
         other text
         NETGRS VALUE
-INCLUDE  /path_to_netgrs_file/net_to_gross.inc
+        INCLUDE  /path_to_netgrs_file/net_to_gross.inc
 
         LIST
 
         POROSITY VALUE
-        !ANOTHER COMMENT 
+        !ANOTHER COMMENT
         INCLUDE path/to/porosity.inc
-    KX CON
-    25.2
-    """
+        KX CON
+        25.2
+        """
+        self.new_grid_array_definition = GridArrayDefinition(value='/new_path_to_netgrs_file/new_net_to_gross_file.inc',
+                                                             modifier='VALUE')
 
-    # mock uuid
-    mocker.patch('ResSimpy.DataModelBaseClasses.GridArrayDefinition.uuid4',
-                 side_effect=uuid_side_effect())
+    def test_load_grid_with_ids(self, mocker):
+        # mock uuid
+        mocker.patch('ResSimpy.DataModelBaseClasses.GridArrayDefinition.uuid4',
+                     side_effect=uuid_side_effect())
 
-    def mock_open_wrapper(filename, mode):
-        mock_open = mock_multiple_files(mocker, filename, potential_file_dict=
-        {'test_location/grid.dat': grid_text,
-            '/path_to_netgrs_file/net_to_gross.inc': '',
-         'path/to/porosity.inc': '',
-         os.path.join('test_location', 'path/to/porosity.inc'): '',
-         }).return_value
-        return mock_open
+        def mock_open_wrapper(filename, mode):
+            mock_open = mock_multiple_files(mocker, filename, potential_file_dict={
+                'test_location/grid.dat': self.grid_text,
+                '/path_to_netgrs_file/net_to_gross.inc': '',
+                'path/to/porosity.inc': '',
+                os.path.join('test_location', 'path/to/porosity.inc'): '',
+            }).return_value
+            return mock_open
 
-    mocker.patch("builtins.open", mock_open_wrapper)
-    
-    grid_nexus_file = NexusFile.generate_file_include_structure(file_path='test_location/grid.dat')
-    
-    grid = NexusGrid(model_unit_system=UnitSystem.METRIC,
-                     grid_nexus_file=grid_nexus_file)
-    expected_netgrs = GridArrayDefinition(value='/path_to_netgrs_file/net_to_gross.inc',
-                                          absolute_path='/path_to_netgrs_file/net_to_gross.inc',
-                                          modifier='VALUE')
-    
-    expected_porosity = GridArrayDefinition(value='path/to/porosity.inc',
-                                            absolute_path=os.path.join('test_location', 'path/to/porosity.inc'),
-                                            modifier='VALUE')
-    expected_kx = GridArrayDefinition(value='25.2', modifier='CON')
+        mocker.patch("builtins.open", mock_open_wrapper)
 
-    # uuid number based on how far down the attributes of the NexusGrid the array is
-    expected_netgrs_id = 'uuid0'
-    expected_porosity_id = 'uuid1'
-    expected_kx_id = 'uuid6'
-    
-    expected_object_locs = {'uuid0': [9, 10],
-                            'uuid1': [14, 16],
-                            'uuid6': [17, 18]}
+        grid_nexus_file = NexusFile.generate_file_include_structure(file_path='test_location/grid.dat')
 
-    # Assert
-    assert grid.netgrs == expected_netgrs
-    assert grid.netgrs.id == expected_netgrs_id
-    assert grid.porosity == expected_porosity
-    assert grid.porosity.id == expected_porosity_id
-    assert grid.kx == expected_kx
-    assert grid.kx.id == expected_kx_id
-    
-    assert grid_nexus_file.object_locations == expected_object_locs
+        grid = NexusGrid(model_unit_system=UnitSystem.METRIC,
+                         grid_nexus_file=grid_nexus_file)
+        expected_netgrs = GridArrayDefinition(value='/path_to_netgrs_file/net_to_gross.inc',
+                                              absolute_path='/path_to_netgrs_file/net_to_gross.inc',
+                                              modifier='VALUE')
 
+        expected_porosity = GridArrayDefinition(value='path/to/porosity.inc',
+                                                absolute_path=os.path.join('test_location', 'path/to/porosity.inc'),
+                                                modifier='VALUE')
+        expected_kx = GridArrayDefinition(value='25.2', modifier='CON')
 
-def test_modify_nexus_grid_basic_test(mocker):
-    # Arrange
-    grid_text = """! Grid dimensions
-    NX NY NZ
-    1 2 3
-    test string
-    DUMMY VALUE
-    ! comment
-    !dummy text
+        # uuid number based on how far down the attributes of the NexusGrid the array is
+        expected_netgrs_id = 'uuid0'
+        expected_porosity_id = 'uuid1'
+        expected_kx_id = 'uuid6'
 
-    other text
-    NETGRS VALUE
-    NOLIST
-    INCLUDE  /path_to_netgrs_file/net_to_gross.inc
+        expected_object_locs = {'uuid0': [9, 10],
+                                'uuid1': [14, 16],
+                                'uuid6': [17, 18]}
 
-    LIST
+        # Assert
+        assert grid.netgrs == expected_netgrs
+        assert grid.netgrs.id == expected_netgrs_id
+        assert grid.porosity == expected_porosity
+        assert grid.porosity.id == expected_porosity_id
+        assert grid.kx == expected_kx
+        assert grid.kx.id == expected_kx_id
 
-    POROSITY VALUE
-    !ANOTHER COMMENT 
-    INCLUDE path/to/porosity.inc
-KX CON
-25.2
-"""
-    expected_output = """! Grid dimensions
-    NX NY NZ
-    1 2 3
-    test string
-    DUMMY VALUE
-    ! comment
-    !dummy text
+        assert grid_nexus_file.object_locations == expected_object_locs
 
-    other text
+    def test_nexus_grid_remove_basic_test(self, mocker):
+        # mock uuid
+        mocker.patch('ResSimpy.DataModelBaseClasses.GridArrayDefinition.uuid4',
+                     side_effect=uuid_side_effect())
+        expected_output = """! Grid dimensions
+        NX NY NZ
+        1 2 3
+        test string
+        DUMMY VALUE
+        ! comment
+        !dummy text
+
+        other text
+
+        LIST
+
+        POROSITY VALUE
+        !ANOTHER COMMENT
+        INCLUDE path/to/porosity.inc
+        KX CON
+        25.2
+        """
+
+        def mock_open_wrapper(filename, mode):
+            mock_open = mock_multiple_files(mocker, filename, potential_file_dict={
+                'test_location/grid.dat': self.grid_text,
+                '/path_to_netgrs_file/net_to_gross.inc': '',
+                'path/to/porosity.inc': '',
+                os.path.join('test_location', 'path/to/porosity.inc'): '',
+            }).return_value
+            return mock_open
+
+        mocker.patch("builtins.open", mock_open_wrapper)
+        grid_nexus_file = NexusFile.generate_file_include_structure(file_path='test_location/grid.dat')
+        grid = NexusGrid(model_unit_system=UnitSystem.METRIC,
+                         grid_nexus_file=grid_nexus_file)
+        array_to_remove = 'netgrs'
+        # Act
+        grid.remove(array=array_to_remove)
+        # Assert
+        assert grid_nexus_file.file_content_as_list == expected_output.splitlines(keepends=True)
+        assert grid.netgrs == GridArrayDefinition()
+
+    def test_nexus_grid_modify_basic_test(self, mocker):
+        # mock uuid
+        mocker.patch('ResSimpy.DataModelBaseClasses.GridArrayDefinition.uuid4',
+                     side_effect=uuid_side_effect())
+        expected_output = """! Grid dimensions
+        NX NY NZ
+        1 2 3
+        test string
+        DUMMY VALUE
+        ! comment
+        !dummy text
+
+        other text
 NETGRS VALUE
-    NOLIST
 INCLUDE /new_path_to_netgrs_file/new_net_to_gross_file.inc
 
-    LIST
+        LIST
 
-    POROSITY
-    VALUE
-    !ANOTHER COMMENT 
-    INCLUDE path/to/porosity.inc
-KX CON
-25.2
-"""
-    # mock uuid
-    mocker.patch('ResSimpy.DataModelBaseClasses.GridArrayDefinition.uuid4',
-                 side_effect=uuid_side_effect())
+        POROSITY VALUE
+        !ANOTHER COMMENT
+        INCLUDE path/to/porosity.inc
+        KX CON
+        25.2
+        """
+        
+        def mock_open_wrapper(filename, mode):
+            mock_open = mock_multiple_files(mocker, filename, potential_file_dict={
+                'test_location/grid.dat': self.grid_text,
+                '/path_to_netgrs_file/net_to_gross.inc': '',
+                'path/to/porosity.inc': '',
+                os.path.join('test_location', 'path/to/porosity.inc'): '',
+            }).return_value
+            return mock_open
 
-    def mock_open_wrapper(filename, mode):
-        mock_open = mock_multiple_files(mocker, filename, potential_file_dict=
-        {'/path_to_netgrs_file/net_to_gross.inc': '',
-         'path/to/porosity.inc': '',
-         }).return_value
-        return mock_open
-
-    mocker.patch("builtins.open", mock_open_wrapper)
-    
-    new_grid_array_definition = GridArrayDefinition(value='/new_path_to_netgrs_file/new_net_to_gross_file.inc',
-                                                    modifier='VALUE')
-    grid = NexusGrid(model_unit_system=UnitSystem.METRIC,
-                     grid_nexus_file=NexusFile(location='test_location/grid.dat',
-                                               file_content_as_list=grid_text.splitlines(keepends=True)))
-    array_to_modify = 'NETGRS'
-    # Act
-    grid.modify(array=array_to_modify, new_properties=new_grid_array_definition)
-    # Assert
-    assert grid_text == expected_output
+        mocker.patch("builtins.open", mock_open_wrapper)
+        grid_nexus_file = NexusFile.generate_file_include_structure(file_path='test_location/grid.dat')
+        grid = NexusGrid(model_unit_system=UnitSystem.METRIC,
+                         grid_nexus_file=grid_nexus_file)
+        array_to_modify = 'NETGRS'
+        # Act
+        grid.modify(array=array_to_modify, new_properties=self.new_grid_array_definition)
+        # Assert
+        assert grid_nexus_file.file_content_as_list == expected_output.splitlines(keepends=True)
+        # check the ids:
+        assert grid.netgrs.id == self.new_grid_array_definition.id
+        assert grid.netgrs == self.new_grid_array_definition

--- a/tests/Nexus/test_modify_nexus_grid.py
+++ b/tests/Nexus/test_modify_nexus_grid.py
@@ -1,0 +1,151 @@
+import os
+import uuid
+
+import pytest
+
+from ResSimpy.DataModelBaseClasses.GridArrayDefinition import GridArrayDefinition
+from ResSimpy.Enums.UnitsEnum import UnitSystem
+from ResSimpy.Nexus.DataModels.NexusFile import NexusFile
+from ResSimpy.Nexus.DataModels.StructuredGrid.NexusGrid import NexusGrid
+from multifile_mocker import mock_multiple_files
+from utility_for_tests import uuid_side_effect
+
+
+def test_load_grid_with_ids(mocker):
+    grid_text = """! Grid dimensions
+        NX NY NZ
+        1 2 3
+        test string
+        DUMMY VALUE
+        ! comment
+        !dummy text
+
+        other text
+        NETGRS VALUE
+INCLUDE  /path_to_netgrs_file/net_to_gross.inc
+
+        LIST
+
+        POROSITY VALUE
+        !ANOTHER COMMENT 
+        INCLUDE path/to/porosity.inc
+    KX CON
+    25.2
+    """
+
+    # mock uuid
+    mocker.patch('ResSimpy.DataModelBaseClasses.GridArrayDefinition.uuid4',
+                 side_effect=uuid_side_effect())
+
+    def mock_open_wrapper(filename, mode):
+        mock_open = mock_multiple_files(mocker, filename, potential_file_dict=
+        {'test_location/grid.dat': grid_text,
+            '/path_to_netgrs_file/net_to_gross.inc': '',
+         'path/to/porosity.inc': '',
+         os.path.join('test_location', 'path/to/porosity.inc'): '',
+         }).return_value
+        return mock_open
+
+    mocker.patch("builtins.open", mock_open_wrapper)
+    
+    grid_nexus_file = NexusFile.generate_file_include_structure(file_path='test_location/grid.dat')
+    
+    grid = NexusGrid(model_unit_system=UnitSystem.METRIC,
+                     grid_nexus_file=grid_nexus_file)
+    expected_netgrs = GridArrayDefinition(value='/path_to_netgrs_file/net_to_gross.inc',
+                                          absolute_path='/path_to_netgrs_file/net_to_gross.inc',
+                                          modifier='VALUE')
+    
+    expected_porosity = GridArrayDefinition(value='path/to/porosity.inc',
+                                            absolute_path=os.path.join('test_location', 'path/to/porosity.inc'),
+                                            modifier='VALUE')
+    expected_kx = GridArrayDefinition(value='25.2', modifier='CON')
+
+    # uuid number based on how far down the attributes of the NexusGrid the array is
+    expected_netgrs_id = 'uuid0'
+    expected_porosity_id = 'uuid1'
+    expected_kx_id = 'uuid6'
+    
+    expected_object_locs = {'uuid0': [9, 10],
+                            'uuid1': [14, 16],
+                            'uuid6': [17, 18]}
+
+    # Assert
+    assert grid.netgrs == expected_netgrs
+    assert grid.netgrs.id == expected_netgrs_id
+    assert grid.porosity == expected_porosity
+    assert grid.porosity.id == expected_porosity_id
+    assert grid.kx == expected_kx
+    assert grid.kx.id == expected_kx_id
+    
+    assert grid_nexus_file.object_locations == expected_object_locs
+
+
+def test_modify_nexus_grid_basic_test(mocker):
+    # Arrange
+    grid_text = """! Grid dimensions
+    NX NY NZ
+    1 2 3
+    test string
+    DUMMY VALUE
+    ! comment
+    !dummy text
+
+    other text
+    NETGRS VALUE
+    NOLIST
+    INCLUDE  /path_to_netgrs_file/net_to_gross.inc
+
+    LIST
+
+    POROSITY VALUE
+    !ANOTHER COMMENT 
+    INCLUDE path/to/porosity.inc
+KX CON
+25.2
+"""
+    expected_output = """! Grid dimensions
+    NX NY NZ
+    1 2 3
+    test string
+    DUMMY VALUE
+    ! comment
+    !dummy text
+
+    other text
+    NETGRS VALUE
+    NOLIST
+INCLUDE /new_path_to_netgrs_file/new_net_to_gross_file.inc
+
+    LIST
+
+    POROSITY
+    VALUE
+    !ANOTHER COMMENT 
+    INCLUDE path/to/porosity.inc
+KX CON
+25.2
+"""
+    # mock uuid
+    mocker.patch('ResSimpy.DataModelBaseClasses.GridArrayDefinition.uuid4',
+                 side_effect=uuid_side_effect())
+
+    def mock_open_wrapper(filename, mode):
+        mock_open = mock_multiple_files(mocker, filename, potential_file_dict=
+        {'/path_to_netgrs_file/net_to_gross.inc': '',
+         'path/to/porosity.inc': '',
+         }).return_value
+        return mock_open
+
+    mocker.patch("builtins.open", mock_open_wrapper)
+    
+    new_grid_array_definition = GridArrayDefinition(value='/new_path_to_netgrs_file/new_net_to_gross_file.inc',
+                                                    modifier='VALUE')
+    grid = NexusGrid(model_unit_system=UnitSystem.METRIC,
+                     grid_nexus_file=NexusFile(location='test_location/grid.dat',
+                                               file_content_as_list=grid_text.splitlines(keepends=True)))
+    array_to_modify = 'NETGRS'
+    # Act
+    grid.modify(array=array_to_modify, new_properties=new_grid_array_definition)
+    # Assert
+    assert grid_text == expected_output

--- a/tests/Nexus/test_modify_nexus_grid.py
+++ b/tests/Nexus/test_modify_nexus_grid.py
@@ -1,12 +1,10 @@
 import os
-import uuid
-import pytest
 from ResSimpy.DataModelBaseClasses.GridArrayDefinition import GridArrayDefinition
 from ResSimpy.Enums.UnitsEnum import UnitSystem
 from ResSimpy.Nexus.DataModels.NexusFile import NexusFile
 from ResSimpy.Nexus.DataModels.StructuredGrid.NexusGrid import NexusGrid
-from multifile_mocker import mock_multiple_files
-from utility_for_tests import uuid_side_effect
+from tests.multifile_mocker import mock_multiple_files
+from tests.utility_for_tests import uuid_side_effect
 
 class TestModifyNexusGrid:
     def setup_method(self, mocker):

--- a/tests/Nexus/test_modify_nexus_grid.py
+++ b/tests/Nexus/test_modify_nexus_grid.py
@@ -113,7 +113,7 @@ KX CON
     !dummy text
 
     other text
-    NETGRS VALUE
+NETGRS VALUE
     NOLIST
 INCLUDE /new_path_to_netgrs_file/new_net_to_gross_file.inc
 

--- a/tests/test_grid_array_definition.py
+++ b/tests/test_grid_array_definition.py
@@ -29,3 +29,16 @@ def test_grid_array_definition_max_min(mocker, modifier, value):
     # Assert
     assert result_max == expected_max
     assert result_min == expected_min
+
+
+@pytest.mark.parametrize('modifier, value, array, expected_result', [
+    ('VALUE', '/some/path/to/file.dat', 'KX', 'KX VALUE\nINCLUDE /some/path/to/file.dat\n'),
+    ('CON', 25, 'porosity', 'POROSITY CON\n25\n'),
+])
+def test_grid_array_definition_to_string(modifier, value, array, expected_result):
+    # Arrange
+    grid_array_definition = GridArrayDefinition(modifier=modifier, value=value, keyword_in_include_file=False)
+    # Act
+    result = grid_array_definition.to_string(array)
+    # Assert
+    assert result == expected_result


### PR DESCRIPTION
Users can now add/remove/modify GridArrayDefinitions on the grid through the `model.grid.modify()` method. Supports id line tracking in the grid file and on GridArrayDefinitions. Also modifies the file_as_list and tracks the files that have changed for updating/writing out the simulator.

Currently only basic tests supported - requires further unit testing.